### PR TITLE
ci(main-apply): add workflow_dispatch with playbook list input

### DIFF
--- a/.github/workflows/main-apply.yml
+++ b/.github/workflows/main-apply.yml
@@ -13,6 +13,12 @@ on:
       - "roles/**"
       - "vars/**/*.yaml"
       - "group_vars/**"
+  workflow_dispatch:
+    inputs:
+      playbooks:
+        description: "Comma-separated playbook paths to apply (e.g. playbooks/individual/ocean/monitoring/unpoller.yaml). Use for vault-only fixes or any redeploy not picked up by the push path filter."
+        required: true
+        type: string
 
 env:
   ANSIBLE_FORCE_COLOR: "true"
@@ -37,10 +43,17 @@ jobs:
 
       - name: Find changed playbooks
         id: find-playbooks
+        env:
+          DISPATCH_PLAYBOOKS: ${{ github.event.inputs.playbooks }}
         run: |
           set -euo pipefail
-          echo "Detecting changed files in last commit..."
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          if [[ -n "${DISPATCH_PLAYBOOKS:-}" ]]; then
+            echo "Manual dispatch — using provided playbooks list..."
+            CHANGED_FILES=$(echo "$DISPATCH_PLAYBOOKS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$')
+          else
+            echo "Detecting changed files in last commit..."
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          fi
           echo "Changed files:"
           echo "$CHANGED_FILES"
           echo ""


### PR DESCRIPTION
## Summary

`main-apply.yml`'s push trigger filters on `playbooks/**`, `files/**`, `roles/**`, `vars/**`, `group_vars/**` — and rightly excludes `vault/**` so secret rotations don't smear changes across every host. But it means a vault-only fix can't trigger a redeploy of the consuming service.

This came up just now: PR #18 (fix(vault): restore unifi monitor password) merged with no main-apply run, leaving unpoller still 403-looping.

Adds a `workflow_dispatch` input taking a comma-separated list of playbook paths. The input feeds the same `detect-impacted-playbooks.sh` pipeline the push path uses, so concurrency grouping, target derivation, and the summary all behave identically.

## Test plan

- [ ] Trigger via `gh workflow run main-apply.yml -f playbooks=playbooks/individual/ocean/monitoring/unpoller.yaml` — confirms unpoller redeploys with the correct password.
- [ ] Verify `docker logs unpoller --tail 10` on ocean no longer shows 403 / "re-authenticating" loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)