### PR TITLE
feat(my-ta-jose): bundle languagetool sidecar for mechanics pre-pass

### DIFF
--- a/files/my_ta_jose/docker-compose.yml.j2
+++ b/files/my_ta_jose/docker-compose.yml.j2
@@ -58,9 +58,14 @@ services:
       - TZ=America/Los_Angeles
       - Java_Xms=256m
       - Java_Xmx=1500m
+      # Google ngram data for confusion-pair detection (their/there,
+      # affect/effect). Points at the parent dir holding en/{1,2,3}grams;
+      # the playbook downloads and extracts it before this container starts.
+      - langtool_languageModel=/ngrams
 
     volumes:
-      - languagetool_ngrams:/ngrams
+      # ~9GB of Lucene ngram indexes, populated on the host by the playbook.
+      - {{ home }}/ngrams:/ngrams:ro
 
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8010/v2/languages"]
@@ -72,13 +77,13 @@ services:
     security_opt:
       - no-new-privileges:true
 
+    # ngram indexes are memory-mapped (off-heap), so heap stays at 1500m but the
+    # limit is raised for index page-cache headroom — at 2048m almost nothing
+    # stays cached and every confusion-pair lookup hits disk.
     cpus: '1.0'
-    mem_limit: 2048m
+    mem_limit: 4096m
 
     logging:
       driver: journald
       options:
         tag: "languagetool"
-
-volumes:
-  languagetool_ngrams:

--- a/files/my_ta_jose/docker-compose.yml.j2
+++ b/files/my_ta_jose/docker-compose.yml.j2
@@ -10,12 +10,24 @@ services:
 
     environment:
       - TZ=America/Los_Angeles
+      # Mechanics pre-pass: deterministic spelling/grammar/punctuation via the
+      # bundled languagetool sibling, reached by compose service-name DNS.
+      # Unset this and my-ta-jose skips the pre-pass, letting the LLM mark
+      # mechanics on its own.
+      - LANGUAGETOOL_URL=http://languagetool:8010
 
     ports:
       - "0.0.0.0:{{ port_ext }}:{{ port_int }}"
 
     volumes:
       - {{ home }}/data:/app/data
+
+    # llama.cpp is published on the host (0.0.0.0:{{ service_ports.llamacpp.port }}).
+    # This service used to sit on docker0 and reach it via 172.17.0.1, but it now
+    # lives on the compose network so it can resolve `languagetool` by name, so
+    # reach the host through that network's gateway instead.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:{{ port_int }}/healthz"]
@@ -24,9 +36,49 @@ services:
       retries: 3
       start_period: 30s
 
+    depends_on:
+      languagetool:
+        condition: service_healthy
+
     logging:
       driver: journald
       options:
         tag: "{{ service }}"
 
-    network_mode: bridge
+  # Deterministic mechanics engine (LanguageTool HTTP API) for my-ta-jose's
+  # pre-pass. Internal only: no published ports, reachable solely over the
+  # compose network by the my_ta_jose service via service-name DNS.
+  languagetool:
+    image: erikvl87/languagetool
+    container_name: languagetool
+    hostname: languagetool
+    restart: unless-stopped
+
+    environment:
+      - TZ=America/Los_Angeles
+      - Java_Xms=256m
+      - Java_Xmx=1500m
+
+    volumes:
+      - languagetool_ngrams:/ngrams
+
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8010/v2/languages"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+    security_opt:
+      - no-new-privileges:true
+
+    cpus: '1.0'
+    mem_limit: 2048m
+
+    logging:
+      driver: journald
+      options:
+        tag: "languagetool"
+
+volumes:
+  languagetool_ngrams:

--- a/files/my_ta_jose/my_ta_jose.env.j2
+++ b/files/my_ta_jose/my_ta_jose.env.j2
@@ -2,8 +2,10 @@
 # Rendered from files/my_ta_jose/my_ta_jose.env.j2 with values from vault/secrets.yaml
 # Vault keys live under the top-level `my_ta_jose:` group.
 
-# LLM endpoint (llama.cpp on the same host's bridge gateway)
-LLAMACPP_BASE_URL=http://172.17.0.1:{{ service_ports.llamacpp.port }}
+# LLM endpoint. llama.cpp is published on the host; reach it via the compose
+# network's host gateway (see extra_hosts in docker-compose.yml.j2). This used
+# to be the docker0 gateway 172.17.0.1 back when the container ran on docker0.
+LLAMACPP_BASE_URL=http://host.docker.internal:{{ service_ports.llamacpp.port }}
 LLAMACPP_MODEL={{ my_ta_jose.llamacpp_model | default('Qwen3-14B-Q4_K_M') }}
 LLAMACPP_API_KEY='{{ ai_services.llamacpp.api_keys.my_ta_jose | default("") }}'
 

--- a/playbooks/individual/ocean/services/my_ta_jose.yaml
+++ b/playbooks/individual/ocean/services/my_ta_jose.yaml
@@ -51,6 +51,65 @@
       group: "{{ user }}"
       mode: '0750'
 
+  # LanguageTool confusion-pair detection (their/there, affect/effect) needs
+  # Google ngram data: a ~9GB one-time download. The sentinel makes it
+  # idempotent so later deploys skip it. LanguageTool crash-loops if
+  # langtool_languageModel points at an incomplete en/{1,2,3}grams tree, so the
+  # download + extract must fully succeed before the compose template (which
+  # sets langtool_languageModel) is rendered and the service restarted — hence
+  # these run first, and the sentinel is only written after a clean extract.
+  - name: Ensure unzip is installed (extracts the ngram dataset)
+    ansible.builtin.apt:
+      name: unzip
+      state: present
+      update_cache: true
+      cache_valid_time: 3600
+
+  - name: Ensure ngram data directory exists
+    ansible.builtin.file:
+      path: "{{ home }}/ngrams/en"
+      state: directory
+      owner: "{{ user }}"
+      group: "{{ user }}"
+      mode: '0755'
+
+  - name: Check whether English ngram data is already present
+    ansible.builtin.stat:
+      path: "{{ home }}/ngrams/.ngrams-en-complete"
+    register: ngram_marker
+
+  - name: Download English ngram dataset
+    ansible.builtin.get_url:
+      url: https://languagetool.org/download/ngram-data/ngrams-en-20150817.zip
+      dest: "{{ home }}/ngrams/ngrams-en-20150817.zip"
+      mode: '0644'
+      timeout: 3600
+    when: not ngram_marker.stat.exists
+
+  - name: Extract English ngram dataset into en/
+    ansible.builtin.unarchive:
+      src: "{{ home }}/ngrams/ngrams-en-20150817.zip"
+      dest: "{{ home }}/ngrams/en"
+      remote_src: true
+      owner: "{{ user }}"
+      group: "{{ user }}"
+    when: not ngram_marker.stat.exists
+
+  - name: Mark ngram extraction complete
+    ansible.builtin.file:
+      path: "{{ home }}/ngrams/.ngrams-en-complete"
+      state: touch
+      owner: "{{ user }}"
+      group: "{{ user }}"
+      mode: '0644'
+    when: not ngram_marker.stat.exists
+
+  - name: Remove ngram zip to reclaim space
+    ansible.builtin.file:
+      path: "{{ home }}/ngrams/ngrams-en-20150817.zip"
+      state: absent
+    when: not ngram_marker.stat.exists
+
   - name: Create docker-compose.yml
     ansible.builtin.template:
       src: "{{ files }}/docker-compose.yml.j2"


### PR DESCRIPTION
Bundles LanguageTool as a sibling service in the my-ta-jose compose stack so the new opt-in mechanics pre-pass has a deterministic spelling/grammar/punctuation engine to hit before the LLM call. Wired via `LANGUAGETOOL_URL=http://languagetool:8010`; if unset, my-ta-jose short-circuits and the LLM does all marking.

Internal only: no published ports, no reverse proxy. Reached purely over the compose network by service-name DNS.

## Network change
`network_mode: bridge` gives no service-name DNS, so it's dropped — both services now land on the compose default network where `languagetool` resolves. That moves `my_ta_jose` off docker0, so its llama.cpp hop switches from the hardcoded docker0 gateway `172.17.0.1:8080` to `host.docker.internal:8080` via `extra_hosts: host-gateway`. llama.cpp publishes on the host's `0.0.0.0:8080`, so it stays reachable through the new network's gateway. nginx → my_ta_jose is unaffected (it hits the host published port `172.17.0.1:8092`, independent of the container's network).

## Verify after deploy
- `docker compose -p my_ta_jose ps` — both Up, languagetool `(healthy)`
- `docker compose -p my_ta_jose exec my_ta_jose curl -fsS http://languagetool:8010/v2/languages`
- Grade a paper with known spelling errors; mechanics marks should appear as red strikethroughs.