### PR TITLE
fix(ci): install ansible in deploy-ocean-service jobs

### DIFF
--- a/.github/workflows/deploy-ocean-service.yml
+++ b/.github/workflows/deploy-ocean-service.yml
@@ -123,6 +123,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Ansible
+        run: |
+          python3 -m pip install --user --quiet ansible
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Validate YAML syntax
         run: |
           echo "Validating YAML syntax for ${{ needs.determine-playbook.outputs.playbook }}"
@@ -150,6 +155,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: |
+          python3 -m pip install --user --quiet ansible
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Set up SSH keys
         run: ssh-add -l || echo "No SSH keys loaded"
@@ -195,6 +205,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: |
+          python3 -m pip install --user --quiet ansible
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Set up SSH keys
         run: ssh-add -l || echo "No SSH keys loaded"


### PR DESCRIPTION
`deploy-ocean-service.yml`'s `validate`, `dry-run`, and `deploy` jobs all call `ansible-playbook` but never install it. The runner's ansible is a `pip install --user` in `~/.local/bin`, which isn't on PATH, so they fail with `ansible-playbook: command not found` (exit 127). `validate` gates `deploy`, so **every** ocean-service deploy is currently skipped.

Discovered while trying to deploy #22 (prometheus/nginx/grafana) — run [26541831410](https://github.com/bluefishforsale/homelab/actions/runs/26541831410) shows validate failing and deploy skipped.

Fix mirrors the working `deploy-my-ta-jose.yml`: add an Install Ansible step (`pip install --user --quiet ansible` + add `~/.local/bin` to `$GITHUB_PATH`) to each of the three jobs.