### PR TITLE
ci: move ansible-lint out of the deploy path into PR-only CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
-skip_list:
-  - name[template]
-  - yaml[indentation]
+# Minimal enforced profile. The playbooks predate ansible-lint adoption and
+# carry stylistic deviations (e.g. `yes`/`no` truthy values) that the stricter
+# profiles flag; `min` enforces the rules that catch real breakage (parse
+# errors, load failures, syntax) without a repo-wide style rewrite.
+profile: min

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,8 @@
 # profiles flag; `min` enforces the rules that catch real breakage (parse
 # errors, load failures, syntax) without a repo-wide style rewrite.
 profile: min
+
+# Retained from the prior config (pre-existing tuning).
+skip_list:
+  - name[template]
+  - yaml[indentation]

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -102,25 +102,33 @@ jobs:
     name: Lint Ansible Playbooks
     runs-on: [self-hosted, homelab, ansible]
     environment: Github Actions CI
-    needs: validate-ansible
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # The self-hosted runner's system python is 3.8, too old for a current
+      # ansible-lint (needs 3.9+). Provision a modern interpreter so lint runs
+      # for real instead of crashing on import.
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install Ansible and ansible-lint
-        run: |
-          python3 -m pip install --user --quiet ansible ansible-lint
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: python3 -m pip install --quiet ansible ansible-lint
 
       - name: Lint playbooks
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "Linting Ansible playbooks..."
-          ansible-lint playbooks/*.yaml || true
-          echo "✓ Ansible lint complete"
+          # ansible-lint loads vars_files (incl. the encrypted vault), so give
+          # it the password; otherwise it reports load-failure (a min-profile
+          # rule). Profile is pinned to `min` in .ansible-lint.
+          echo "$ANSIBLE_VAULT_PASSWORD" > /tmp/.vault_pass
+          chmod 600 /tmp/.vault_pass
+          trap 'rm -f /tmp/.vault_pass' EXIT
+          export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/.vault_pass
+          ansible-lint playbooks/
 
   validate-templates:
     name: Validate Jinja2 Templates

--- a/.github/workflows/deploy-ocean-service.yml
+++ b/.github/workflows/deploy-ocean-service.yml
@@ -116,7 +116,7 @@ jobs:
           echo "📋 Service '$SERVICE' → Playbook: $PLAYBOOK"
 
   validate:
-    name: Validate & Lint
+    name: Validate
     needs: determine-playbook
     runs-on: [self-hosted, homelab, ansible]
     steps:
@@ -137,15 +137,6 @@ jobs:
         run: |
           echo "Validating Ansible playbook syntax"
           ansible-playbook --syntax-check ${{ needs.determine-playbook.outputs.playbook }}
-
-      - name: Lint playbook
-        run: |
-          if command -v ansible-lint &> /dev/null; then
-            echo "Running ansible-lint"
-            ansible-lint ${{ needs.determine-playbook.outputs.playbook }}
-          else
-            echo "⚠️  ansible-lint not found, skipping"
-          fi
 
   dry-run:
     name: Dry-Run (Check Mode)


### PR DESCRIPTION
`deploy-ocean-service.yml` hard-gated every deploy on `ansible-lint`, which never worked on the runner (system Python 3.8; modern ansible-lint needs 3.9+). Lint is a code-quality check, not a "should this config ship" gate — and the repo already treated it as advisory (`Makefile` runs it with `|| true`, `requirements.txt` has it commented out).

- **Deploy path**: drop the lint step from the `validate` job in `deploy-ocean-service.yml`. Syntax-check still gates structural correctness; deploys no longer hinge on a broken linter. (This unblocks #22's prometheus/nginx/grafana deploy.)
- **PR CI**: the `lint-ansible` job in `ci-validate.yml` already existed but was `continue-on-error` + `|| true` under the broken 3.8 interpreter, so it never actually ran. Now it provisions Python 3.11 via `setup-python`, installs a current ansible-lint, lints the whole `playbooks/` tree, decrypts the vault (so `load-failure` can't false-fire), and enforces for real (no masking). Made independent of the syntax job.
- **`.ansible-lint`**: pin `profile: min` (verified: the 128-file tree passes clean at min), keeping the pre-existing `skip_list`.

Lint now runs where it belongs — on PRs — and deploys are decoupled from it.