### PR TITLE
fix(runners): pin runner image to debian-bookworm (py3.11)

### DIFF
--- a/inventories/github_runners/group_vars/github_runners.yml
+++ b/inventories/github_runners/group_vars/github_runners.yml
@@ -90,7 +90,10 @@ github_runner_count: 4
 #   - May require additional configuration for Docker support
 #   - Less documented for ephemeral mode
 github_runner_image: "myoung34/github-runner"
-github_runner_version: "latest"
+# debian-bookworm = Debian 12 / Python 3.11 (matches the homelab host OS and is
+# new enough for current ansible-lint). The old "latest" tag is ubuntu-focal
+# (20.04 / Python 3.8), which crashes modern Python tooling.
+github_runner_version: "debian-bookworm"
 
 # ============================================================================
 # EPHEMERAL CONFIGURATION

--- a/roles/github_docker_runners/defaults/main.yml
+++ b/roles/github_docker_runners/defaults/main.yml
@@ -38,7 +38,10 @@ github_runner_count: 4
 #   - myoung34/github-runner:latest (recommended, excellent ephemeral support)
 #   - ghcr.io/actions/actions-runner:latest (official, less documented for ephemeral mode)
 github_runner_image: "myoung34/github-runner"
-github_runner_version: "latest"
+# debian-bookworm = Debian 12 / Python 3.11 (matches the homelab host OS and is
+# new enough for current ansible-lint). The old "latest" tag is ubuntu-focal
+# (20.04 / Python 3.8), which crashes modern Python tooling.
+github_runner_version: "debian-bookworm"
 
 # Ephemeral runner configuration
 # When true, runners will:


### PR DESCRIPTION
The self-hosted runners run `myoung34/github-runner:latest` = **ubuntu-focal (20.04 / Python 3.8)**. Python 3.8 is the root cause behind the deploy-runner CI breakage: a current `ansible-lint` crashes on import (`functools.cache` needs 3.9+), and #23/#25/#26 were all working around symptoms of this stale base.

This pins the tag to **`debian-bookworm`** — Debian 12 / Python 3.11:
- Matches the homelab host OS (Debian) rather than Ubuntu.
- New enough for modern Python tooling (ansible-lint, etc.).
- Same purpose-built runner image — no custom image to build or maintain. (A from-scratch minimal/alpine runner isn't worth it: the Actions agent + ansible + docker CLI need a general-purpose base.)

Set in both `roles/github_docker_runners/defaults/main.yml` and `inventories/github_runners/group_vars/github_runners.yml` (the authoritative override). The role is already on master, so this is just the tag change.

## Apply (manual, never CI)
Runner changes can't be deployed by the runners themselves (a runner recreating its own container kills the in-flight job). From the homelab network:

```
ansible-playbook -i inventories/github_runners/hosts.ini \
  playbooks/individual/infrastructure/github_docker_runners.yaml
```

Drain/let in-flight jobs finish first. After it's up, confirm `docker exec github-runner-1 python3 --version` reports 3.11.

## Follow-up
Once runners are on 3.11, the `setup-python` step added in #25's PR-lint job becomes redundant and can be simplified back out.