### PR TITLE
fix(runners): set PIP_BREAK_SYSTEM_PACKAGES for the bookworm base

### DIFF
--- a/roles/github_docker_runners/templates/docker-compose.yml.j2
+++ b/roles/github_docker_runners/templates/docker-compose.yml.j2
@@ -26,6 +26,12 @@ services:
     restart: always
     
     environment:
+      # The debian-bookworm base marks system python as PEP 668
+      # externally-managed, which makes `pip install` refuse. Workflows on this
+      # runner pip-install ansible, so allow it runner-wide (every job inherits
+      # this) rather than setting it per-workflow.
+      PIP_BREAK_SYSTEM_PACKAGES: "1"
+
       # GitHub repository/organization URL
       # For myoung34/github-runner image, use REPO_URL for both org and repo scope
 {% if github_scope == 'org' %}


### PR DESCRIPTION
Follow-on to #27. The `debian-bookworm` runner base (Debian 12) marks system Python as PEP 668 externally-managed (`/usr/lib/python3.11/EXTERNALLY-MANAGED` is present), so `pip install` refuses with `externally-managed-environment`. Verified on the live runner.

Workflows pip-install ansible on the runner, so without this the 9 deploy workflows that don't already set the flag (`deploy-ocean-service`, `deploy-my-ta-jose`, `deploy-globalview(-backend)`, `deploy-paia`, `deploy-blog-terrac-com`, `deploy-registry-cache`, `deploy-terrac-com`, `deploy-photonic-inventory`) would fail at their install step.

Set `PIP_BREAK_SYSTEM_PACKAGES=1` in the runner container env so every job inherits it — one place instead of editing each workflow.

## Apply (manual, never CI)
From the homelab network, after merge:
```
ansible-playbook -i inventories/github_runners/hosts.ini \
  playbooks/individual/infrastructure/github_docker_runners.yaml
```
Drain in-flight jobs first.