### PR TITLE
chore(ci): drop setup-python from lint job (runner is now py3.11)

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -106,16 +106,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # The self-hosted runner's system python is 3.8, too old for a current
-      # ansible-lint (needs 3.9+). Provision a modern interpreter so lint runs
-      # for real instead of crashing on import.
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Install Ansible and ansible-lint
-        run: python3 -m pip install --quiet ansible ansible-lint
+        run: |
+          python3 -m pip install --user --quiet ansible ansible-lint
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Lint playbooks
         env:


### PR DESCRIPTION
Final cleanup of the runner-upgrade chain. The `setup-python` step in the `lint-ansible` job was a workaround for the old focal/Python-3.8 runner. The runner is now `debian-bookworm` / Python 3.11 (#27), so the lint job can use the runner's native `python3` directly — matching the `validate-ansible` job.

`PIP_BREAK_SYSTEM_PACKAGES` is set both at the workflow env level (here) and on the runner (#28), so the `--user` install works under the bookworm PEP-668 base.

This PR's own `ci-validate` run exercises the change (lint-ansible now runs without setup-python) — green here = confirmed working on the upgraded runner.