### PR TITLE
fix(ansible): stop ssh writing known_hosts on ephemeral runners

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -43,5 +43,9 @@ enable_plugins = ini, yaml
 become = True
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+# host_key_checking=False above sets StrictHostKeyChecking=no, but ssh still
+# tries to append each host key to known_hosts. The ephemeral CI runners mount
+# /root/.ssh read-only with no known_hosts, so that append fails and every host
+# comes back UNREACHABLE. Discard host keys (/dev/null) so ssh never writes.
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 control_path = ~/.ansible/cp/%%C


### PR DESCRIPTION
All homelab deploy/apply workflows started failing with `UNREACHABLE! Failed to add the host to the list of known hosts (/root/.ssh/known_hosts)` on every host after the runner containers were recreated for the bookworm migration.

Root cause: `ansible.cfg` sets `host_key_checking = False` (→ `StrictHostKeyChecking=no`), but ssh still tries to *append* each host's key to `known_hosts`. The ephemeral runners mount `/root/.ssh` read-only and ship no `known_hosts`, so the append fails and ansible reports the host UNREACHABLE — for every host, not just new ones.

Fix: add `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no` to `ssh_args` so ssh discards host keys rather than writing them. Correct posture for ephemeral runners, consistent with the existing `host_key_checking=False`, and self-applies on the next run (ansible reads this repo's `ansible.cfg`) — no runner change needed.