### PR TITLE
chore(inventory): disable k8s nodes (cluster not running)

### DIFF
--- a/inventories/production/hosts.ini
+++ b/inventories/production/hosts.ini
@@ -33,8 +33,11 @@ dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005"
 dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006"
 
 [k8s]
-kube501 ansible_user=debian bare_metal_host="node005"
-kube502 ansible_user=debian bare_metal_host="node005"
-kube503 ansible_user=debian bare_metal_host="node005"
-kube511 ansible_user=debian bare_metal_host="node005"
+# Cluster is not currently running. Hosts commented out so they stay out of
+# groups['all'] and `hosts: all` playbooks (cloudflared, base, etc.) skip them.
+# Uncomment to reactivate when the cluster is back.
+# kube501 ansible_user=debian bare_metal_host="node005"
+# kube502 ansible_user=debian bare_metal_host="node005"
+# kube503 ansible_user=debian bare_metal_host="node005"
+# kube511 ansible_user=debian bare_metal_host="node005"
 


### PR DESCRIPTION
The k8s cluster isn't currently running, so `kube501/502/503/511` reject SSH (`Permission denied (publickey)` — they were never provisioned with the runner key). Their presence in `groups['all']` makes every `hosts: all` playbook (cloudflared's per-host SSH tunnels, base, etc.) fail on them.

Comment the four `[k8s]` hosts out so they're skipped, keeping the config for when the cluster comes back. Verified `ansible-inventory` no longer lists them.