### PR TITLE
fix(ci): skip task-include files in playbook syntax-check

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -79,6 +79,14 @@ jobs:
           echo "$ANSIBLE_VAULT_PASSWORD" > /tmp/.vault_pass
           chmod 600 /tmp/.vault_pass
 
+          # Some *.yaml under playbooks/ are task includes (e.g.
+          # terminalbench_model.yaml, pulled in via include_tasks), not plays.
+          # --syntax-check treats every file as a playbook and errors on those,
+          # so skip anything that isn't a list of plays (hosts/import_playbook).
+          is_playbook() {
+            python3 -c "import yaml,sys; d=yaml.safe_load(open(sys.argv[1])); sys.exit(0 if isinstance(d,list) and all(isinstance(i,dict) and ('hosts' in i or 'import_playbook' in i) for i in d) else 1)" "$1"
+          }
+
           echo "Validating Ansible playbook syntax..."
           for playbook in playbooks/*.yaml; do
             if [ -f "$playbook" ]; then
@@ -87,10 +95,14 @@ jobs:
             fi
           done
 
-          # Also check individual playbooks
+          # Also check individual playbooks (skipping task-include files)
           find playbooks/individual -name "*.yaml" | while read playbook; do
-            echo "Checking $playbook"
-            ansible-playbook --syntax-check --vault-password-file=/tmp/.vault_pass -i .github/ci_inventory.ini "$playbook"
+            if is_playbook "$playbook"; then
+              echo "Checking $playbook"
+              ansible-playbook --syntax-check --vault-password-file=/tmp/.vault_pass -i .github/ci_inventory.ini "$playbook"
+            else
+              echo "Skipping $playbook (task include, not a playbook)"
+            fi
           done
 
           # Clean up


### PR DESCRIPTION
Fixes the long-standing `ci-validate` failure: `terminalbench_model.yaml` is a task include (pulled via `include_tasks` from `terminalbench.yaml:55`), not a playbook, but the validate-ansible loop ran `ansible-playbook --syntax-check` on it → `'ansible.builtin.template' is not a valid attribute for a Play`, failing every PR. It's the only non-playbook `*.yaml` under `playbooks/individual/`. Now the loop skips files that aren't a list of plays. This PR's own ci-validate run verifies it.