### PR TITLE
fix(mtr-exporter): add --init to reap mtr child zombies

### DIFF
--- a/files/ocean-prometheus/mtr-exporter.service.j2
+++ b/files/ocean-prometheus/mtr-exporter.service.j2
@@ -13,7 +13,7 @@ RestartSec=120s
 TimeoutStartSec=180s
 ExecStartPre=-docker rm -f {{ mtr_exporter_service }}
 ExecStartPre=-/usr/bin/docker pull {{ mtr_exporter_image }}:{{ mtr_exporter_version }}
-ExecStart=docker run --rm \
+ExecStart=docker run --rm --init \
     --name {{ mtr_exporter_service }} \
     --hostname {{ mtr_exporter_service }} \
     --cap-add NET_RAW \


### PR DESCRIPTION
**Emergency root cause.** ocean hit ~27,600 `[mtr] <defunct>` processes (3 days' worth at ~4/min) and 100% CPU. `mtr-exporter` runs `mtr` for 4 jobs `@every 60s`, but the container's PID 1 (the `mgumz/mtr-exporter` binary) doesn't `wait()` on the finished `mtr` children, so each becomes a permanent zombie. All were parented to the single container PID, confirming a classic PID-1-doesn't-reap leak. The `docker run` lacks `--init`.

Fix: run with `--init` so tini becomes PID 1 and reaps the `mtr` children.

Mitigation already applied live on ocean: `mtr-exporter.service` is **stopped + disabled** and the swarm cleared (27662 → 0). With this fix merged, a `prometheus.yaml` deploy can safely re-enable it; without it, re-enabling would resume the leak.