### PR TITLE
feat(terminalbench): run benchmarks on a dedicated CPU-capped llamacpp

### DIFF
--- a/files/ocean-prometheus/mtr-exporter.service.j2
+++ b/files/ocean-prometheus/mtr-exporter.service.j2
@@ -13,7 +13,7 @@ RestartSec=120s
 TimeoutStartSec=180s
 ExecStartPre=-docker rm -f {{ mtr_exporter_service }}
 ExecStartPre=-/usr/bin/docker pull {{ mtr_exporter_image }}:{{ mtr_exporter_version }}
-ExecStart=docker run --rm \
+ExecStart=docker run --rm --init \
     --name {{ mtr_exporter_service }} \
     --hostname {{ mtr_exporter_service }} \
     --cap-add NET_RAW \

--- a/files/ocean-terminalbench/docker-compose.yml.j2
+++ b/files/ocean-terminalbench/docker-compose.yml.j2
@@ -1,31 +1,19 @@
 services:
-  llamacpp:
+  terminalbench-llamacpp:
     image: ghcr.io/ggerganov/llama.cpp:server-cuda
-    container_name: llamacpp
-    hostname: llamacpp
+    container_name: terminalbench-llamacpp
+    hostname: terminalbench-llamacpp
     restart: unless-stopped
-
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu, compute, utility]
 
     environment:
       - TZ=America/Los_Angeles
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=all
-      - CUDA_VISIBLE_DEVICES=0
 
     ports:
-      - "8080:8080"
+      - "{{ terminalbench_llamacpp_port }}:8080"
 
     volumes:
-      - /data01/services/llamacpp/models:/models
-      - /data01/services/llamacpp/config:/config
-      - /data01/services/llamacpp/logs:/logs
+      # Shared model files, read-only — never writes into the production llamacpp dir.
+      - /data01/services/llamacpp/models:/models:ro
 
     command:
       - "--host"
@@ -34,8 +22,14 @@ services:
       - "8080"
       - "--model"
       - "/models/{{ bench_model }}"
+      # CPU-only by design: keep the GPU entirely for the production llamacpp.
+      # (0 = no layers offloaded.) Thread count matches the cpus cap below.
       - "--n-gpu-layers"
-      - "-1"
+      - "0"
+      - "--threads"
+      - "8"
+      - "--threads-batch"
+      - "8"
       - "--ctx-size"
       - "{{ bench_ctx_size }}"
       - "--parallel"
@@ -44,9 +38,8 @@ services:
       - "2048"
       - "--ubatch-size"
       - "512"
-      - "--flash-attn"
       - "--api-key"
-      - "llamacpp-homelab-key"
+      - "{{ terminalbench_api_key }}"
       - "--metrics"
 
     healthcheck:
@@ -58,5 +51,9 @@ services:
 
     security_opt:
       - no-new-privileges:true
+
+    # Hard caps so benchmarking can't starve the host (CPU inference is heavy).
+    cpus: '8.0'
+    mem_limit: 24g
 
     network_mode: bridge

--- a/playbooks/individual/core/services/dns_ha_stack.yaml
+++ b/playbooks/individual/core/services/dns_ha_stack.yaml
@@ -36,7 +36,7 @@
   pre_tasks:
     - name: Load HA role-specific variables
       ansible.builtin.include_vars:
-        file: "{{ playbook_dir }}/roles/dns_infrastructure/vars/ha_{{ 'primary' if inventory_hostname == 'dns02' else 'standby' }}.yaml"
+        file: "{{ playbook_dir }}/../../../../roles/dns_infrastructure/vars/ha_{{ 'primary' if inventory_hostname == 'dns02' else 'standby' }}.yaml"
 
   roles:
     - role: dns_infrastructure

--- a/playbooks/individual/ocean/ai/terminalbench.yaml
+++ b/playbooks/individual/ocean/ai/terminalbench.yaml
@@ -11,7 +11,6 @@
     - "{{ playbook_dir }}/../../../../vars/vars_service_ports.yaml"
 
   vars:
-    llamacpp_home: /data01/services/llamacpp
     benchmark_models: >-
       {{ llamacpp_models | dict2items
          | map(attribute='value') | flatten
@@ -19,13 +18,16 @@
 
   tasks:
 
-    - name: Ensure benchmark output directory exists
+    - name: Ensure terminalbench llamacpp + output directories exist
       ansible.builtin.file:
-        path: "{{ terminalbench_output_dir }}"
+        path: "{{ item }}"
         state: directory
         owner: media
         group: media
         mode: '0755'
+      loop:
+        - "{{ terminalbench_llamacpp_home }}"
+        - "{{ terminalbench_output_dir }}"
 
     - name: Check if uv is installed
       ansible.builtin.command: which uv
@@ -57,3 +59,10 @@
       loop_control:
         loop_var: bench_model_item
         label: "{{ bench_model_item.name }}"
+
+    - name: Tear down the terminalbench llamacpp instance
+      ansible.builtin.command:
+        cmd: docker compose down
+        chdir: "{{ terminalbench_llamacpp_home }}"
+      changed_when: true
+      failed_when: false

--- a/playbooks/individual/ocean/ai/terminalbench_model.yaml
+++ b/playbooks/individual/ocean/ai/terminalbench_model.yaml
@@ -5,7 +5,7 @@
 - name: "Write benchmark docker-compose.yml for {{ bench_model_item.name }}"
   ansible.builtin.template:
     src: "{{ playbook_dir }}/../../../../files/ocean-terminalbench/docker-compose.yml.j2"
-    dest: "{{ llamacpp_home }}/docker-compose.yml"
+    dest: "{{ terminalbench_llamacpp_home }}/docker-compose.yml"
     owner: media
     group: media
     mode: '0644'
@@ -13,10 +13,14 @@
     bench_model: "{{ bench_model_item.name }}"
     bench_ctx_size: "{{ terminalbench_benchmark_ctx_size }}"
 
-- name: "Restart llamacpp for {{ bench_model_item.name }}"
-  ansible.builtin.systemd:
-    name: llamacpp.service
-    state: restarted
+# Recreate the dedicated bench instance with this model. This manages only the
+# terminalbench-llamacpp container in its own dir — it never touches the
+# production llamacpp.service.
+- name: "(Re)create the terminalbench llamacpp instance for {{ bench_model_item.name }}"
+  ansible.builtin.command:
+    cmd: docker compose up -d --force-recreate
+    chdir: "{{ terminalbench_llamacpp_home }}"
+  changed_when: true
 
 - name: "Wait for llamacpp to be healthy ({{ bench_model_item.name }})"
   ansible.builtin.uri:

--- a/vars/vars_terminalbench.yaml
+++ b/vars/vars_terminalbench.yaml
@@ -2,10 +2,17 @@
 terminalbench_dataset: "terminal-bench@2.0"
 terminalbench_agent: "terminus-2"
 terminalbench_benchmark_ctx_size: 8192
-terminalbench_output_dir: /data01/services/llamacpp/benchmarks
-terminalbench_api_base: "http://localhost:8080/v1"
+
+# Dedicated, CPU-only llamacpp instance for benchmarking. It is fully separate
+# from the production llamacpp (own dir, container name, and port {{ terminalbench_llamacpp_port }})
+# so a bench run never rewrites or restarts the production service.
+terminalbench_llamacpp_home: /data01/services/terminalbench-llamacpp
+terminalbench_llamacpp_port: 8082
+
+terminalbench_output_dir: /data01/services/terminalbench-llamacpp/benchmarks
+terminalbench_api_base: "http://localhost:8082/v1"
 terminalbench_api_key: "llamacpp-homelab-key"
-terminalbench_health_url: "http://localhost:8080/health"
+terminalbench_health_url: "http://localhost:8082/health"
 terminalbench_health_timeout: 180
 terminalbench_health_interval: 10
 terminalbench_n_concurrent: 1


### PR DESCRIPTION
**Part 1 of the terminalbench rework.** Stops terminalbench from hijacking the production llamacpp.

Previously `terminalbench_model.yaml` overwrote `/data01/services/llamacpp/docker-compose.yml` and restarted `llamacpp.service` for each benchmark model — which is exactly what knocked production llamacpp onto CPU. Now:

- Dedicated `terminalbench-llamacpp` container, own dir `/data01/services/terminalbench-llamacpp`, host port **8082**, models mounted **read-only** from the shared dir. The production compose/service are never touched.
- **CPU-only** (`--n-gpu-layers 0`, `--threads 8`) so the GPU stays 100% for production; **capped at 8 cores / 24 GB** (`cpus: '8.0'`, `mem_limit: 24g`).
- Per model: `docker compose up -d --force-recreate` in the bench dir; torn down when the run finishes. harbor `api_base`/`health` repointed to `:8082`.

Part 2 (results → Prometheus textfile → Grafana "Model Benchmarks" dashboard + committed repo summary) is a follow-up — see PR discussion for the two blockers.