### PR TITLE
feat(terminalbench): add terminalbench_n_tasks knob (harbor -l)

### DIFF
--- a/playbooks/individual/ocean/ai/terminalbench_model.yaml
+++ b/playbooks/individual/ocean/ai/terminalbench_model.yaml
@@ -48,6 +48,7 @@
         --agent {{ terminalbench_agent }}
         --model openai/{{ bench_model_item.name }}
         -n {{ terminalbench_n_concurrent }}
+        {% if terminalbench_n_tasks | int > 0 %}-l {{ terminalbench_n_tasks }}{% endif %}
       args:
         chdir: "{{ bench_tmpdir.path }}"
       environment:

--- a/vars/vars_terminalbench.yaml
+++ b/vars/vars_terminalbench.yaml
@@ -16,3 +16,9 @@ terminalbench_health_url: "http://localhost:8082/health"
 terminalbench_health_timeout: 180
 terminalbench_health_interval: 10
 terminalbench_n_concurrent: 1
+
+# Maximum number of tasks to run from the dataset (harbor's -l/--n-tasks).
+# 0 = no limit (run the whole dataset, the production default). Set >0 for a
+# fast capture / smoke run (e.g. -e terminalbench_n_tasks=1 captures schema in
+# one task on CPU).
+terminalbench_n_tasks: 0


### PR DESCRIPTION
Adds an optional `terminalbench_n_tasks` var (default `0` = no limit) that maps to harbor's `-l/--n-tasks`. The harbor command in `terminalbench_model.yaml` appends `-l N` only when the var is `>0`, so production runs are unchanged.

Primary use: fast schema/smoke capture. With `-e terminalbench_n_tasks=1` each benchmark-eligible model runs one task — minutes on CPU rather than the whole `terminal-bench@2.0` dataset.

This unblocks Part 2 of the terminalbench rework (results parser + Grafana dashboard + auto-commit) — I'll capture the real harbor result JSON from a one-task run and build the parser against it.