### PR TITLE
feat(ci): main-apply --extra-vars + skip terminalbench from auto-apply

### DIFF
--- a/.github/workflows/lib/detect-impacted-playbooks.sh
+++ b/.github/workflows/lib/detect-impacted-playbooks.sh
@@ -74,6 +74,16 @@ while IFS= read -r path; do
     continue
   fi
 
+  # Terminalbench is on-demand only — its playbook runs a multi-hour CPU
+  # benchmark and must never auto-apply on push. Changes to its playbook,
+  # tasks file, vars, or files dir are dispatched manually via
+  # workflow_dispatch (with -e terminalbench_n_tasks=N for fast captures).
+  if [[ "$path" == playbooks/individual/ocean/ai/terminalbench*.yaml ]] \
+     || [[ "$path" == vars/vars_terminalbench.yaml ]] \
+     || [[ "$path" == files/ocean-terminalbench/* ]]; then
+    continue
+  fi
+
   # Direct playbook edits
   if [[ "$path" =~ ^playbooks/individual/.*\.ya?ml$ ]] \
      && [[ "$path" != playbooks/individual/*/tasks/* ]]; then

--- a/.github/workflows/main-apply.yml
+++ b/.github/workflows/main-apply.yml
@@ -19,6 +19,11 @@ on:
         description: "Comma-separated playbook paths to apply (e.g. playbooks/individual/ocean/monitoring/unpoller.yaml). Use for vault-only fixes or any redeploy not picked up by the push path filter."
         required: true
         type: string
+      extra_vars:
+        description: "Optional ansible --extra-vars (e.g. 'terminalbench_n_tasks=1' or 'key1=v1 key2=v2'). Applied to every playbook in this dispatch."
+        required: false
+        type: string
+        default: ""
 
 env:
   ANSIBLE_FORCE_COLOR: "true"
@@ -130,11 +135,18 @@ jobs:
         id: apply
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+          EXTRA_VARS: ${{ inputs.extra_vars || '' }}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
 
           PLAYBOOKS='${{ needs.detect-changes.outputs.playbooks }}'
           INVENTORY="inventories/production/hosts.ini"
+
+          # Optional --extra-vars from workflow_dispatch input (empty on push).
+          EXTRA_VARS_FLAG=()
+          if [ -n "$EXTRA_VARS" ]; then
+            EXTRA_VARS_FLAG=(--extra-vars "$EXTRA_VARS")
+          fi
 
           echo "================================================"
           echo "Applying playbooks to production infrastructure"
@@ -164,6 +176,7 @@ jobs:
             ansible-playbook \
               -i "$INVENTORY" \
               --vault-password-file=/tmp/.vault_pass \
+              "${EXTRA_VARS_FLAG[@]}" \
               "$PLAYBOOK" 2>&1 | tee /tmp/playbook-${TOTAL}.log
             ANSIBLE_EXIT=${PIPESTATUS[0]}
             if [ "$ANSIBLE_EXIT" -eq 0 ]; then


### PR DESCRIPTION
Two small CI tweaks so the terminalbench workflow (whose `--n-tasks` knob landed in #36) can actually be triggered, without auto-firing on push.

1. **`main-apply.yml`**: new optional `extra_vars` workflow_dispatch input. When set, the apply step appends `--extra-vars "<value>"` to every `ansible-playbook` in the dispatch. Empty on push (unchanged behaviour there).
2. **`detect-impacted-playbooks.sh`**: skip `playbooks/individual/ocean/ai/terminalbench*.yaml`, `vars/vars_terminalbench.yaml`, and `files/ocean-terminalbench/**`. The terminalbench playbook runs a multi-hour CPU benchmark and must never auto-apply on push — it is dispatched deliberately.

After this merges:

```
gh workflow run main-apply.yml \
  -f playbooks=playbooks/individual/ocean/ai/terminalbench.yaml \
  -f extra_vars='terminalbench_n_tasks=1'
```

…runs a one-task schema-capture on each benchmark-eligible model (minutes on CPU instead of hours). I parse the captured JSON, then ship Part 2 (parser + `.prom` exporter + commit step + dashboard) as one PR.