### PR TITLE
fix(ci): main-apply workflow_dispatch bypasses detect-impacted-playbooks.sh

### DIFF
--- a/.github/workflows/main-apply.yml
+++ b/.github/workflows/main-apply.yml
@@ -53,18 +53,25 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -n "${DISPATCH_PLAYBOOKS:-}" ]]; then
-            echo "Manual dispatch — using provided playbooks list..."
+            # workflow_dispatch is an explicit user intent — trust the input
+            # verbatim instead of routing it through the auto-detect script,
+            # which is meant for push-time file→playbook mapping and applies
+            # exclusions (e.g. terminalbench) that legitimately need to be
+            # dispatchable.
+            echo "Manual dispatch — using provided playbooks list verbatim..."
             CHANGED_FILES=$(echo "$DISPATCH_PLAYBOOKS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$')
+            echo "$CHANGED_FILES"
+            echo ""
+            PLAYBOOK_JSON=$(echo "$CHANGED_FILES" | jq -R . | jq -s -c .)
           else
             echo "Detecting changed files in last commit..."
             CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+            echo ""
+            PLAYBOOK_JSON=$(echo "$CHANGED_FILES" \
+              | bash .github/workflows/lib/detect-impacted-playbooks.sh)
           fi
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-          echo ""
-
-          PLAYBOOK_JSON=$(echo "$CHANGED_FILES" \
-            | bash .github/workflows/lib/detect-impacted-playbooks.sh)
 
           COUNT=$(echo "$PLAYBOOK_JSON" | jq 'length')
 


### PR DESCRIPTION
Caught immediately after #37: dispatching `terminalbench.yaml` through `main-apply` produced **Apply: skipped**. Cause is mine — #37's terminalbench exclusion in `detect-impacted-playbooks.sh` was meant to stop push auto-apply, but `main-apply` was piping the `workflow_dispatch` `playbooks` input through the same script, so the exclusion silently dropped explicit dispatches too.

Fix: when `DISPATCH_PLAYBOOKS` is set (i.e. workflow_dispatch), build the playbook JSON directly from the user's input (verbatim) and skip the auto-detect script. Push keeps using the script (with its exclusions) as before.

Once merged I'll re-dispatch the terminalbench schema-capture:
```
gh workflow run main-apply.yml \
  -f playbooks=playbooks/individual/ocean/ai/terminalbench.yaml \
  -f extra_vars='terminalbench_n_tasks=1'
```