### PR TITLE
photonic: SMTP env for user-invite emails

### DIFF
--- a/files/photonic_inventory/photonic_inventory.env.j2
+++ b/files/photonic_inventory/photonic_inventory.env.j2
@@ -18,3 +18,16 @@ ARGON2_PEPPER='{{ photonic_inventory.argon2_pepper | default("UNSET") }}'
 
 # Seeded on first boot only, if the admin row does not yet exist.
 BOOTSTRAP_ADMIN_EMAIL={{ photonic_inventory.bootstrap_admin_email | default('admin@terrac.com') }}
+
+# Outbound email for user invite links (Gmail SMTP + app password from vault).
+# When SMTP_PASSWORD is unset the app falls back to showing the invite link to
+# the admin instead of sending it. App password is single-quoted in case it
+# contains characters compose would interpolate; spaces stripped (Gmail rejects
+# the spaced display form).
+SMTP_HOST={{ photonic_inventory.smtp_host | default('smtp.gmail.com') }}
+SMTP_PORT={{ photonic_inventory.smtp_port | default('587') }}
+SMTP_STARTTLS={{ photonic_inventory.smtp_starttls | default('true') }}
+SMTP_USER={{ photonic_inventory.smtp_user | default(photonic_inventory.bootstrap_admin_email | default('')) }}
+SMTP_FROM={{ photonic_inventory.smtp_from | default(photonic_inventory.smtp_user | default(photonic_inventory.bootstrap_admin_email | default(''))) }}
+SMTP_PASSWORD='{{ photonic_inventory.gmail_app_password | default("") | replace(" ", "") }}'
+PUBLIC_BASE_URL={{ photonic_inventory.public_base_url | default('https://inventory.terrac.com') }}


### PR DESCRIPTION
Renders SMTP_* + PUBLIC_BASE_URL into the photonic_inventory container env from the vault (key `photonic_inventory.gmail_app_password`, spaces stripped). With the password unset the app falls back to showing the invite link, so merging is safe before/independent of the vault key being populated.

Deploys on the next photonic_inventory deploy (or `gh workflow run deploy-photonic-inventory.yml -R bluefishforsale/homelab`). Split out of the terminalbench WIP branch onto a clean branch off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)