### PR TITLE
fix(ci): deploy summary breaks on commit messages containing quotes

### DIFF
--- a/.github/workflows/deploy-globalview-backend.yml
+++ b/.github/workflows/deploy-globalview-backend.yml
@@ -146,12 +146,14 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
           BRANCH="${{ steps.params.outputs.branch }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
 
           if [ "$STATUS" = "success" ]; then
             STATUS_EMOJI="✅"; STATUS_TEXT="DEPLOYMENT SUCCESSFUL"

--- a/.github/workflows/deploy-globalview.yml
+++ b/.github/workflows/deploy-globalview.yml
@@ -146,12 +146,14 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
           BRANCH="${{ steps.params.outputs.branch }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
 
           if [ "$STATUS" = "success" ]; then
             STATUS_EMOJI="✅"; STATUS_TEXT="DEPLOYMENT SUCCESSFUL"

--- a/.github/workflows/deploy-my-ta-jose.yml
+++ b/.github/workflows/deploy-my-ta-jose.yml
@@ -146,12 +146,14 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
           BRANCH="${{ steps.params.outputs.branch }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
 
           if [ "$STATUS" = "success" ]; then
             STATUS_EMOJI="✅"; STATUS_TEXT="DEPLOYMENT SUCCESSFUL"

--- a/.github/workflows/deploy-paia.yml
+++ b/.github/workflows/deploy-paia.yml
@@ -160,12 +160,14 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
           BRANCH="${{ steps.params.outputs.branch }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
 
           if [ "$STATUS" = "success" ]; then
             STATUS_EMOJI="✅"; STATUS_TEXT="DEPLOYMENT SUCCESSFUL"

--- a/.github/workflows/deploy-photonic-inventory.yml
+++ b/.github/workflows/deploy-photonic-inventory.yml
@@ -142,12 +142,14 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
           BRANCH="${{ steps.params.outputs.branch }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
 
           if [ "$STATUS" = "success" ]; then
             STATUS_EMOJI="✅"; STATUS_TEXT="DEPLOYMENT SUCCESSFUL"

--- a/.github/workflows/deploy-terrac-com.yml
+++ b/.github/workflows/deploy-terrac-com.yml
@@ -174,11 +174,13 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          DEPLOY_COMMIT_MESSAGE: ${{ steps.params.outputs.commit_message }}
         run: |
           BRANCH="${{ steps.params.outputs.branch }}"
           FORCE_CLEAN="${{ steps.params.outputs.force_clean }}"
           COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
-          COMMIT_MESSAGE="${{ steps.params.outputs.commit_message }}"
+          COMMIT_MESSAGE="$DEPLOY_COMMIT_MESSAGE"
           STATUS="${{ env.deployment_status || 'unknown' }}"
           DURATION="${{ env.deployment_duration || 'N/A' }}"
 


### PR DESCRIPTION
## Problem
A commit whose message contains a double quote (e.g. a `Revert "feat: ..."` commit) fails the **Generate deployment summary** step with `command not found` / exit 127. The value was inlined via `${{ steps.params.outputs.commit_message }}` directly into a double-quoted shell assignment, so the inner quotes closed the string early and the next word was parsed as a command.

The ansible deploy itself **succeeded** (the step reported `STATUS=success` before the summary step ran) — only the cosmetic summary step failed and marked the whole run ❌.

## Fix
Pass the commit message through the step's `env:` (`DEPLOY_COMMIT_MESSAGE`) and reference it as a shell variable, so the shell reads it as a literal env value with no re-tokenization. Same pattern the params step already trusts.

Applied to all six dispatch deploy workflows that shared the copy-pasted step:
- deploy-photonic-inventory.yml
- deploy-globalview.yml / deploy-globalview-backend.yml
- deploy-terrac-com.yml
- deploy-paia.yml
- deploy-my-ta-jose.yml

Workflow-only change; does not match `main-apply`'s push path filter, so merging won't trigger a fleet apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)