### PR TITLE
fix(backup): point grafana_url at the real grafana port (8910)

### DIFF
--- a/playbooks/operations/backup/grafana_dashboards.yaml
+++ b/playbooks/operations/backup/grafana_dashboards.yaml
@@ -10,9 +10,11 @@
 
   vars_files:
     - "{{ playbook_dir }}/../../../vault/secrets.yaml"
+    - "{{ playbook_dir }}/../../../vars/vars_service_ports.yaml"
 
   vars:
-    grafana_url: "http://192.168.1.143:3000"
+    # 3000 used to land here by accident — that's open-webui, not Grafana.
+    grafana_url: "http://192.168.1.143:{{ service_ports.grafana.port }}"
     grafana_api_user: "terrac"
     grafana_api_password: "{{ monitoring.grafana.terrac_password }}"
     backup_dir: "{{ playbook_dir }}/../../../files/grafana-compose/dashboards"


### PR DESCRIPTION
The backup playbook had \`grafana_url: \"http://192.168.1.143:3000\"\` — that port is **open-webui**, not Grafana (which is 8910 per \`vars_service_ports.yaml:46\`). The retry I added in #42 worked exactly as intended; it just kept catching the wrong endpoint.

From the failed main-apply on the #42 merge (run 27101038194), the recorded response was:
\`\`\`
url: http://192.168.1.143:3000/api/search?type=dash-db
status: 200
content_type: text/html; charset=utf-8
server: uvicorn
\`\`\`

Replaces the hardcoded port with \`{{ service_ports.grafana.port }}\` from \`vars_service_ports.yaml\` so it stays correct if the port ever moves.