### PR TITLE
fix(backup): use admin creds for grafana API (terrac account is 401)

### DIFF
--- a/playbooks/operations/backup/grafana_dashboards.yaml
+++ b/playbooks/operations/backup/grafana_dashboards.yaml
@@ -15,8 +15,11 @@
   vars:
     # 3000 used to land here by accident — that's open-webui, not Grafana.
     grafana_url: "http://192.168.1.143:{{ service_ports.grafana.port }}"
-    grafana_api_user: "terrac"
-    grafana_api_password: "{{ monitoring.grafana.terrac_password }}"
+    # Use admin (verified working against the live instance); the `terrac`
+    # account no longer authenticates against this Grafana, so the previous
+    # basic-auth attempts returned 401.
+    grafana_api_user: "admin"
+    grafana_api_password: "{{ monitoring.grafana.admin_password }}"
     backup_dir: "{{ playbook_dir }}/../../../files/grafana-compose/dashboards"
     temp_dir: "/tmp/grafana-dashboard-backup-{{ ansible_date_time.epoch }}"
 


### PR DESCRIPTION
After #44 fixed the port, /api/search returned `401 password-auth.failed` for `terrac`. Verified against the live instance: `admin/admin -> 200`, `terrac/<vault> -> 401` (the terrac account no longer authenticates). The vault already has `monitoring.grafana.admin_password` (matches the live instance); pointing the two playbook vars at it. Everything else from #42 (retries) and #44 (correct port) stays.