### PR TITLE
fix(backup): enable gather_facts (temp_dir uses ansible_date_time.epoch)

### DIFF
--- a/playbooks/operations/backup/grafana_dashboards.yaml
+++ b/playbooks/operations/backup/grafana_dashboards.yaml
@@ -6,7 +6,8 @@
 - name: Backup Grafana Dashboards to Repository
   hosts: ocean
   become: false
-  gather_facts: false
+  # temp_dir uses ansible_date_time.epoch, which needs facts.
+  gather_facts: true
 
   vars_files:
     - "{{ playbook_dir }}/../../../vault/secrets.yaml"


### PR DESCRIPTION
After #45 fixed Grafana auth and the API returned the list cleanly (`Found 37 dashboards to backup`), the next task crashed:

```
Error while resolving value for 'path': 'ansible_date_time' is undefined
  temp_dir: "/tmp/grafana-dashboard-backup-{{ ansible_date_time.epoch }}"
```

The play sets `gather_facts: false` but the var needs facts. Flip it to `true`; nothing else in the playbook needs anything from facts.