### PR TITLE
feat(llamacpp): upgrade ocean local model to Qwen3.6-35B-A3B

### DIFF
--- a/files/llamacpp/docker-compose.yml.j2
+++ b/files/llamacpp/docker-compose.yml.j2
@@ -28,27 +28,34 @@ services:
       - {{ home }}/config:/config
       - {{ home }}/logs:/logs
     
-    # RTX 3090 Optimized: Qwen3-14B for single-user reasoning with max context
-    # Model: 8.5GB + ~7GB KV cache = fits in 16GB VRAM budget
-    # Supports /think mode for step-by-step reasoning
-    command: 
+    # RTX 3090: Qwen3.6-35B-A3B (MoE, ~3B active) for agentic coding + tool use.
+    # ~18GB model + q8_0 KV @ 32K fits the 24GB card. --jinja loads the model's
+    # tool-call chat template (required for tool-calling). Verify at deploy:
+    # CUDA 12.8+ in the image (13.2 reportedly produces gibberish); sanity-test
+    # a tool round-trip before trusting it in the agent loop.
+    command:
       - "--host"
       - "0.0.0.0"
-      - "--port" 
+      - "--port"
       - "{{ port }}"
       - "--model"
-      - "/models/Qwen3-14B-Q4_K_M.gguf"
+      - "/models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
       - "--n-gpu-layers"
-      - "41"
+      - "-1"
       - "--ctx-size"
-      - "40960"
-      - "--parallel" 
+      - "32768"
+      - "--parallel"
       - "1"
       - "--batch-size"
       - "2048"
-      - "--ubatch-size" 
+      - "--ubatch-size"
       - "512"
       - "--flash-attn"
+      - "--cache-type-k"
+      - "q8_0"
+      - "--cache-type-v"
+      - "q8_0"
+      - "--jinja"
       - "--api-key-file"
       - "/config/keys.txt"
       # API only — the built-in chat UI at / is unauthenticated, so disable

--- a/vars/vars_llamacpp_models.yaml
+++ b/vars/vars_llamacpp_models.yaml
@@ -3,6 +3,21 @@
 
 llamacpp_models:
   reasoning:
+    # Active model: MoE 35B / ~3B active, native tool-calling, ~100 tok/s on a
+    # 3090. IQ4_NL (18GB) over Q4_K_M (22.1GB) to leave VRAM for q8_0 KV @ 32K.
+    # Verify HF card + a coding leaderboard at deploy (released 2026-04-15).
+    - name: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+      url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+      size: "18GB"
+      parameters: "35B-A3B (MoE, ~3B active)"
+      vram_usage: "~18GB + q8_0 KV cache (fits 24GB)"
+      capabilities: ["agentic-coding", "tool-calling", "reasoning", "thinking", "repo-level"]
+      context_size: "32K"
+      timeout: 7200
+      priority: 1
+      requires_auth: false
+      benchmark_eligible: true
+
     - name: "Qwen3-14B-Q4_K_M.gguf"
       url: "https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
       size: "8.5GB"
@@ -11,7 +26,7 @@ llamacpp_models:
       capabilities: ["reasoning", "thinking", "step-by-step", "analysis", "math", "coding"]
       context_size: "40K"
       timeout: 3600
-      priority: 1
+      priority: 3
       requires_auth: false
       benchmark_eligible: true
 
@@ -42,6 +57,18 @@ llamacpp_models:
 
 # RTX 3090 Performance Profiles (16GB VRAM budget for headroom)
 rtx_3090_profiles:
+  # Active profile. q8_0 KV (needs flash-attn) keeps 32K context inside 24GB
+  # alongside the 18GB model. --jinja enables the model's tool-call template.
+  single_user_agentic:
+    model: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+    gpu_layers: -1
+    context_size: 32768
+    batch_size: 2048
+    parallel_requests: 1
+    flash_attention: true
+    thinking_mode: true
+    cache_type: q8_0
+
   single_user_reasoning:
     model: "Qwen3-14B-Q4_K_M.gguf"
     gpu_layers: -1
@@ -70,6 +97,7 @@ rtx_3090_profiles:
 
 # Model download priorities (1 = download first)
 download_priority:
-  1: "Qwen3-14B-Q4_K_M.gguf"
+  1: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
   2: "Qwen3-8B-Q4_K_M.gguf"
-  3: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"
+  3: "Qwen3-14B-Q4_K_M.gguf"
+  4: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"


### PR DESCRIPTION
Swaps ocean's llama.cpp model from Qwen3-14B to **Qwen3.6-35B-A3B** (MoE, ~3B active, native tool-calling) for the agentbox free/local lane.

## Changes
- `vars/vars_llamacpp_models.yaml`: `Qwen3.6-35B-A3B-UD-IQ4_NL.gguf` (18GB) as priority-1 download; new `single_user_agentic` profile; 14B demoted to priority 3 (kept as fallback, existing file not deleted).
- `files/llamacpp/docker-compose.yml.j2`: `--model` -> new GGUF, `--n-gpu-layers -1`, `--ctx-size 32768`, `--jinja` (tool-call template), `--cache-type-k/v q8_0`.

## Why IQ4_NL not Q4_K_M
Q4_K_M is 22.1GB; on a 24GB 3090 that leaves almost nothing for KV cache. IQ4_NL (18GB) + q8_0 KV fits 32K context with headroom.

## Verify at deploy (recommendations are past the assistant's training cutoff)
- HF card still lists `Qwen3.6-35B-A3B-UD-IQ4_NL.gguf` at `unsloth/Qwen3.6-35B-A3B-GGUF`, and a current coding leaderboard.
- Image ships CUDA 12.8+ (13.2 reportedly produces gibberish).
- Run one tool round-trip against `llama.home/v1` before trusting it in the agent loop.

Deploys to ocean (recreates the llama.cpp service + triggers an 18GB download). Separate from the agentbox PR (#49) by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)