### PR TITLE
fix(agentbox): vmid 3000 -> 8000 (3000 is pihole)

### DIFF
--- a/playbooks/individual/infrastructure/create_agentbox_vm.yaml
+++ b/playbooks/individual/infrastructure/create_agentbox_vm.yaml
@@ -10,7 +10,7 @@
   become: true
   gather_facts: true
   vars:
-    agentbox_vm_id: 3000
+    agentbox_vm_id: 8000
     agentbox_vm_name: agentbox
     agentbox_vm_hostname: agentbox
     agentbox_vm_cores: 6


### PR DESCRIPTION
vmid 3000 is the running pihole VM. create_agentbox_vm.yaml's idempotency guard (`when: rc != 0 or not running`) saw 3000 running and skipped clone + every setup task, so the agentbox VM was never created and 192.168.1.31 had no host. 8000 is free per the cluster numbering (qm list confirmed). IP/DNS unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)