### PR TITLE
fix(agentbox): set VM cpu type host (Bun needs AVX2)

### DIFF
--- a/playbooks/individual/infrastructure/create_agentbox_vm.yaml
+++ b/playbooks/individual/infrastructure/create_agentbox_vm.yaml
@@ -18,6 +18,10 @@
     agentbox_vm_disk_size_increase: "+48G"  # repos + node toolchain + worktrees
     agentbox_vm_template_id: 9999  # Debian 12 cloud-init template
     agentbox_vm_onboot: 1  # Start on Proxmox host boot
+    # Passthrough host CPU features. The default kvm64 masks AVX2/AVX/SSE4.2,
+    # which Bun-compiled binaries (Claude Code, opencode) require — without them
+    # they deadlock at startup. node005 (E5-2690 v4) has AVX2.
+    agentbox_vm_cpu: host
 
     # Network: resolve via DNS if present, else the static .31 allocation.
     agentbox_vm_ip: "{{ lookup('dig', agentbox_vm_hostname + '.home', errors='ignore') | default('192.168.1.31', true) }}"
@@ -51,6 +55,7 @@
         qm set {{ agentbox_vm_id }} --ipconfig0 ip={{ agentbox_vm_ip }}/{{ agentbox_vm_netmask }},gw={{ agentbox_vm_gateway }}
         qm set {{ agentbox_vm_id }} --nameserver {{ agentbox_vm_nameserver }}
         qm set {{ agentbox_vm_id }} --onboot {{ agentbox_vm_onboot }}
+        qm set {{ agentbox_vm_id }} --cpu {{ agentbox_vm_cpu }}
       when: agentbox_vm_status.rc != 0 or agentbox_vm_status.stdout is not search('running')
       changed_when: true
 


### PR DESCRIPTION
agentbox's VM was cloned with the default `kvm64` CPU ("Common KVM processor"), which masks AVX2/AVX/SSE4.2. Claude Code and opencode are Bun-compiled binaries that **deadlock at startup** without those features (system Node/V8 has a generic fallback, so it ran fine — that's how we isolated it). node005 is a Xeon E5-2690 v4 (Broadwell) with AVX2, so `--cpu host` exposes it to the guest and both binaries run.

Applied live to the existing VM via `qm set 8000 --cpu host` + power-cycle; this makes recreations correct too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)