### PR TITLE
fix(agentbox): quote space-valued env vars

### DIFF
--- a/files/agentbox/agentbox.env.j2
+++ b/files/agentbox/agentbox.env.j2
@@ -20,11 +20,11 @@ GOOGLE_APPLICATION_CREDENTIALS={{ home }}/.config/agentbox/gcloud-sa.json
 
 # Deployable repos the watcher resolves issues for (space-separated, owner/repo
 # resolved against bluefishforsale).
-AGENTBOX_REPOS={{ agentbox_repos | join(' ') }}
+AGENTBOX_REPOS="{{ agentbox_repos | join(' ') }}"
 
 # Opt-in auto-merge allowlist (ADR 0001). Default empty: every PR waits for a
 # human merge. A repo here auto-merges ONLY diffs with no prod-affecting paths.
-AGENTBOX_AUTOMERGE_REPOS={{ agentbox_automerge_repos | join(' ') }}
+AGENTBOX_AUTOMERGE_REPOS="{{ agentbox_automerge_repos | join(' ') }}"
 
 # OpenTelemetry: Claude Code (native) pushes metrics + logs to the local
 # collector. opencode picks up the same OTLP endpoint via its otel plugin. The


### PR DESCRIPTION
The watcher failed every tick with `agentbox.env: line 23: blog_terrac_com: command not found` (exit 127). `AGENTBOX_REPOS={{ ... | join(' ') }}` renders an unquoted space-separated list, which bash `source` reads as `VAR=paia` + run `blog_terrac_com`. Quote both REPOS vars — systemd EnvironmentFile strips the surrounding quotes, and `source` parses a single assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)