### PR TITLE
fix(agentbox): headless RC enable + workspace trust

### DIFF
--- a/files/agentbox/agentbox-rc@.service.j2
+++ b/files/agentbox/agentbox-rc@.service.j2
@@ -14,7 +14,10 @@ Environment=PATH=/usr/local/bin:/usr/bin:/bin
 EnvironmentFile={{ home }}/.config/agentbox/agentbox.env
 Environment=OTEL_RESOURCE_ATTRIBUTES=repo=%i,lane=claude,service=agentbox
 WorkingDirectory={{ home }}/repos/%i
-ExecStart=/usr/bin/env claude remote-control --name %i
+# Wrapper seeds workspace trust and answers the per-launch "Enable Remote
+# Control?" prompt under a pty (Claude Code has no flag for either). See
+# files/agentbox/rc-launch.sh.
+ExecStart=/usr/local/bin/agentbox-rc-launch.sh %i
 Restart=on-failure
 RestartSec=30
 StandardOutput=journal

--- a/files/agentbox/escalate-to-claude.sh
+++ b/files/agentbox/escalate-to-claude.sh
@@ -56,6 +56,9 @@ $body
 
 Make the minimal, correct change; keep the build and tests green."
 
+    # Worktrees are cloned on the fly; trust each before claude reads it
+    # (no flag for the workspace-trust gate).
+    /usr/local/bin/agentbox-trust-dir.sh "$wt" || true
     (cd "$wt" && claude -p "$prompt" --permission-mode acceptEdits) || true
 
     if [ -n "$(git -C "$wt" status --porcelain)" ]; then

--- a/files/agentbox/rc-launch.sh
+++ b/files/agentbox/rc-launch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Launch `claude remote-control` for a repo under systemd.
+# Rendered from files/agentbox/rc-launch.sh. Arg $1 = repo name (= dir under
+# ~/repos and the --name shown in claude.ai/code).
+#
+# Two headless gates Claude Code has no flag for:
+#  1. Per-folder workspace trust -> seed it (trust-dir.sh).
+#  2. "Enable Remote Control? (y/n)" is re-asked on EVERY launch and needs a
+#     TTY; cached grove_enabled does not suppress it. Run under `expect` to
+#     give it a pty, auto-answer y, then block on eof so the unit stays active.
+#
+# ponytail: auto-confirming the prompt + the undocumented trust key are both
+# unsupported community patterns; re-verify after a Claude Code upgrade.
+set -euo pipefail
+
+repo="$1"
+/usr/local/bin/agentbox-trust-dir.sh "${HOME}/repos/${repo}"
+
+exec expect -c "
+  set timeout -1
+  spawn -noecho claude remote-control --name ${repo}
+  expect {
+    \"Enable Remote Control?\" { send \"y\r\"; exp_continue }
+    eof
+  }
+"

--- a/files/agentbox/trust-dir.sh
+++ b/files/agentbox/trust-dir.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Mark a directory as trusted for Claude Code, headlessly.
+# Rendered from files/agentbox/trust-dir.sh.
+#
+# Claude Code gates every workspace behind an interactive "trust this folder?"
+# dialog that remote-control / `claude -p` cannot answer (no TTY). There is no
+# documented setting or flag to bypass it, but the accepted state persists in
+# ~/.claude.json under projects["<dir>"].hasTrustDialogAccepted. We set that key
+# directly so RC sessions and the escalate lane's dynamic worktrees start
+# without a human accepting each folder.
+#
+# ponytail: undocumented key, re-verify after a Claude Code upgrade — if trust
+# prompts return, the schema in ~/.claude.json changed.
+set -euo pipefail
+
+dir="$1"
+cfg="${HOME}/.claude.json"
+
+# No config yet means Claude Code has never run / not logged in; nothing to do.
+[ -f "$cfg" ] || exit 0
+
+python3 - "$cfg" "$dir" <<'PY'
+import json, sys
+cfg, dir = sys.argv[1], sys.argv[2]
+with open(cfg) as f:
+    d = json.load(f)
+proj = d.setdefault("projects", {}).setdefault(dir, {})
+if proj.get("hasTrustDialogAccepted") is not True:
+    proj["hasTrustDialogAccepted"] = True
+    tmp = cfg + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(d, f, indent=2)
+    import os
+    os.replace(tmp, cfg)
+PY

--- a/playbooks/individual/agentbox/agentbox.yaml
+++ b/playbooks/individual/agentbox/agentbox.yaml
@@ -73,6 +73,7 @@
         - git
         - jq
         - tmux
+        - expect
         - nodejs
         - npm
       state: present
@@ -228,6 +229,8 @@
     loop:
       - { src: issue-watcher.sh, dest: agentbox-issue-watcher.sh }
       - { src: escalate-to-claude.sh, dest: agentbox-escalate-to-claude.sh }
+      - { src: trust-dir.sh, dest: agentbox-trust-dir.sh }
+      - { src: rc-launch.sh, dest: agentbox-rc-launch.sh }
 
   # --- systemd units ---
   - name: Install systemd units


### PR DESCRIPTION
Two undocumented Claude Code first-run gates block headless operation, with no flag for either (confirmed via docs):

1. **Workspace trust** (per folder) — `remote-control`/`claude -p` can't show the dialog. Persisted at `~/.claude.json` -> `projects["<dir>"].hasTrustDialogAccepted`. `trust-dir.sh` merges that key in (never clobbers the stateful file — verified oauthAccount preserved). Wired as the RC wrapper's first step and into the escalate lane before `claude -p` (its worktrees are cloned dynamically and can't be hand-trusted).
2. **"Enable Remote Control? (y/n)"** — re-asked on *every* launch and needs a TTY; the cached `grove_enabled` does not suppress it, so the systemd unit exited every time. `rc-launch.sh` runs it under `expect`, answers `y`, and blocks on eof so the unit stays `active`.

RC units now `ExecStart=agentbox-rc-launch.sh %i`; added `expect` to base packages. Both are unsupported community patterns (the plan flagged daemonizing RC as an accepted risk) — commented as fragile, re-verify after Claude Code upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)