### PR TITLE
fix(ci): never auto-apply terminalbench (guard at emit chokepoint)

### DIFF
--- a/.github/workflows/lib/detect-impacted-playbooks.sh
+++ b/.github/workflows/lib/detect-impacted-playbooks.sh
@@ -41,6 +41,15 @@ emit() {
   local pb="$1"
   # Skip playbooks that no longer exist (e.g., deleted/renamed in this commit).
   [[ -f "$REPO_ROOT/$pb" ]] || return 0
+  # Terminalbench is a multi-hour GPU benchmark and must NEVER auto-apply on
+  # push — not even when a shared vars file (e.g. vars_service_ports.yaml)
+  # reverse-maps it into the impacted set. The per-path skip below only catches
+  # edits to terminalbench's own files; this is the catch-all at the single
+  # emit chokepoint. On-demand runs go through workflow_dispatch, which bypasses
+  # this detector entirely.
+  case "$pb" in
+    playbooks/individual/ocean/ai/terminalbench*.yaml) return 0 ;;
+  esac
   if ! grep -qxF "$pb" "$SEEN_FILE" 2>/dev/null; then
     printf '%s\n' "$pb" >> "$SEEN_FILE"
   fi


### PR DESCRIPTION
`terminalbench.yaml` includes `vars/vars_service_ports.yaml`, so editing that shared ports file reverse-mapped terminalbench into the push auto-apply set — the existing per-path skip only catches edits to terminalbench's *own* files. That's how a routine ports change in #49 launched the multi-hour terminal-bench GPU benchmark; cancelling the CI job left `harbor run` executing detached on ocean (holding 15GB VRAM, spawning task containers for hours).

Fix: guard terminalbench at the single `emit()` chokepoint so **no** route (reverse-map included) can auto-apply it on push. `workflow_dispatch` trusts its input verbatim and bypasses this detector, so manual on-demand runs are unaffected.

Verified locally: `vars_service_ports.yaml` → 31 playbooks, terminalbench absent; direct terminalbench edit → `[]`; normal edit → maps to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)