### PR TITLE
feat(terminalbench): disable in code (kill-switch, default off)

### DIFF
--- a/playbooks/individual/ocean/ai/terminalbench.yaml
+++ b/playbooks/individual/ocean/ai/terminalbench.yaml
@@ -18,6 +18,19 @@
 
   tasks:
 
+    # Disabled in code: terminalbench is a multi-hour GPU benchmark with no
+    # ongoing value here (it hijacks the 3090 from production llamacpp). Kept for
+    # reference / ops experience. To run on-demand, dispatch with:
+    #   -e terminalbench_enabled=true
+    - name: Note terminalbench is disabled
+      ansible.builtin.debug:
+        msg: "terminalbench is disabled in code. Dispatch with -e terminalbench_enabled=true to run."
+      when: not (terminalbench_enabled | default(false) | bool)
+
+    - name: End play unless terminalbench is explicitly enabled
+      ansible.builtin.meta: end_play
+      when: not (terminalbench_enabled | default(false) | bool)
+
     - name: Ensure terminalbench llamacpp + output directories exist
       ansible.builtin.file:
         path: "{{ item }}"

--- a/vars/vars_terminalbench.yaml
+++ b/vars/vars_terminalbench.yaml
@@ -1,4 +1,9 @@
 # Terminal-bench evaluation configuration
+# Disabled in code: terminalbench is a multi-hour benchmark with no ongoing
+# value here. The playbook no-ops unless this is overridden true. To run
+# on-demand: dispatch main-apply with -e terminalbench_enabled=true.
+terminalbench_enabled: false
+
 terminalbench_dataset: "terminal-bench@2.0"
 terminalbench_agent: "terminus-2"
 terminalbench_benchmark_ctx_size: 8192


### PR DESCRIPTION
terminalbench is a multi-hour benchmark with no ongoing value here. `terminalbench.yaml` now ends the play immediately unless `terminalbench_enabled=true` (default `false` in `vars_terminalbench.yaml`). Kept for reference; re-enable on-demand with `-e terminalbench_enabled=true`.

Complements #60: that stopped terminalbench from being *auto-applied* on push; this also no-ops an accidental manual dispatch. Both `vars_terminalbench.yaml` and `terminalbench.yaml` are already excluded from auto-apply, so merging this deploys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)