### PR TITLE
fix(agentbox): watcher robustness + premium-lane PR review

### DIFF
--- a/files/agentbox/escalate-to-claude.sh
+++ b/files/agentbox/escalate-to-claude.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 unset ANTHROPIC_API_KEY
 
 OWNER="bluefishforsale"
-WORKROOT="{{ home }}/repos"
+# Separate from repos/ (the RC sessions' cwd) so escalate's clone + commits can't
+# collide with a live remote-control session on the same repo.
+WORKROOT="{{ home }}/work"
 LABEL_WORKING="agent-working"
 LABEL_CLAUDE="needs-claude"
 LABEL_REVIEW="needs-human-merge"
@@ -18,6 +20,14 @@ LABEL_REVIEW="needs-human-merge"
 # shellcheck disable=SC1091
 source "{{ home }}/.config/agentbox/agentbox.env"
 unset ANTHROPIC_API_KEY  # the env file must not set it; enforce here too
+
+# gh add-label fails if the label doesn't exist in the repo; create them first.
+ensure_labels() {
+  local slug="$1"
+  gh label create "$LABEL_WORKING" --repo "$slug" --color FBCA04 --force >/dev/null 2>&1 || true
+  gh label create "$LABEL_CLAUDE"  --repo "$slug" --color 5319E7 --force >/dev/null 2>&1 || true
+  gh label create "$LABEL_REVIEW"  --repo "$slug" --color D93F0B --force >/dev/null 2>&1 || true
+}
 
 # Tiered autonomy (ADR 0001) applies regardless of lane: auto-merge only an
 # opted-in repo whose diff touches no prod-affecting paths; else open + label.
@@ -36,6 +46,7 @@ for repo in ${AGENTBOX_REPOS:-}; do
   slug="$OWNER/$repo"
   # Per-repo/per-lane telemetry labels for everything claude emits this pass.
   export OTEL_RESOURCE_ATTRIBUTES="repo=$repo,lane=claude,service=agentbox"
+  ensure_labels "$slug"
   issues=$(gh issue list --repo "$slug" --state open --label "$LABEL_CLAUDE" \
     --json number --jq '.[].number') || continue
 

--- a/files/agentbox/issue-watcher.sh
+++ b/files/agentbox/issue-watcher.sh
@@ -10,7 +10,11 @@
 set -euo pipefail
 
 OWNER="bluefishforsale"
-WORKROOT="{{ home }}/repos"
+# Separate from repos/ (the RC sessions' cwd) so the watcher's clone + commits
+# can't collide with a live remote-control session on the same repo.
+WORKROOT="{{ home }}/work"
+# Draft logs live OUTSIDE the worktree so `git add -A` never commits them.
+LOGDIR="{{ home }}/agent-logs"
 LABEL_WORKING="agent-working"
 LABEL_CLAUDE="needs-claude"
 LABEL_REVIEW="needs-human-merge"
@@ -18,7 +22,15 @@ LABEL_REVIEW="needs-human-merge"
 # shellcheck disable=SC1091
 source "{{ home }}/.config/agentbox/agentbox.env"
 
-mkdir -p "$WORKROOT"
+mkdir -p "$WORKROOT" "$LOGDIR"
+
+# gh add-label fails if the label doesn't exist in the repo; create them first.
+ensure_labels() {
+  local slug="$1"
+  gh label create "$LABEL_WORKING" --repo "$slug" --color FBCA04 --description "Agent fleet is drafting a fix" --force >/dev/null 2>&1 || true
+  gh label create "$LABEL_CLAUDE"  --repo "$slug" --color 5319E7 --description "Escalated to the Claude Code premium lane" --force >/dev/null 2>&1 || true
+  gh label create "$LABEL_REVIEW"  --repo "$slug" --color D93F0B --description "Agent PR open; a human merges" --force >/dev/null 2>&1 || true
+}
 
 # Paths that, if a diff touches anything outside them, mean the change can
 # affect prod (Shape-A images, homelab plays, app code). Only when EVERY changed
@@ -38,6 +50,7 @@ for repo in ${AGENTBOX_REPOS:-}; do
   slug="$OWNER/$repo"
   # Per-repo/per-lane telemetry labels for everything opencode emits this pass.
   export OTEL_RESOURCE_ATTRIBUTES="repo=$repo,lane=free,service=agentbox"
+  ensure_labels "$slug"
 
   # Open issues not already claimed (agent-working) or escalated (needs-claude).
   issues=$(gh issue list --repo "$slug" --state open --json number,labels \
@@ -60,14 +73,31 @@ $body
 
 Make the minimal, correct change. Do not touch unrelated code. Keep the build and tests green."
 
-    if (cd "$wt" && opencode run "$prompt") >"$wt/.agent-$num.log" 2>&1 \
+    if (cd "$wt" && opencode run "$prompt") >"$LOGDIR/$repo-issue-$num.log" 2>&1 \
        && [ -n "$(git -C "$wt" status --porcelain)" ]; then
       git -C "$wt" add -A
       git -C "$wt" commit -q -m "fix: resolve #$num ($title)"
       git -C "$wt" push -q -u origin "agent/issue-$num"
-      gh pr create --repo "$slug" --head "agent/issue-$num" \
+      pr_url=$(gh pr create --repo "$slug" --head "agent/issue-$num" \
         --title "fix: $title (#$num)" \
-        --body "Resolves #$num. Drafted by agentbox on the free lane." || true
+        --body "Resolves #$num. Drafted by agentbox on the free lane.") || pr_url=""
+
+      # Independent premium-lane review: a stronger model (Claude, on the
+      # fixed-cost subscription) reviews the free lane's draft and comments. The
+      # human still merges — this only informs that decision. Diff is passed in
+      # the prompt (no tools), so no extra permissions are needed.
+      if [ -n "$pr_url" ]; then
+        /usr/local/bin/agentbox-trust-dir.sh "$wt" || true
+        diff=$(git -C "$wt" diff origin/HEAD...HEAD); diff=${diff:0:60000}
+        review=$( cd "$wt" && OTEL_RESOURCE_ATTRIBUTES="repo=$repo,lane=claude,service=agentbox" \
+          claude -p "Review this agent-drafted diff resolving issue #$num ($title) in $slug. Assess correctness, security, and whether it actually fixes the issue. Be concise: bullet concrete problems, otherwise reply LGTM.
+
+$diff" 2>/dev/null ) || review=""
+        [ -n "$review" ] && gh pr comment "$pr_url" --repo "$slug" \
+          --body "Premium-lane review (Claude):
+
+$review" >/dev/null 2>&1 || true
+      fi
 
       # Tiered autonomy (ADR 0001): default is open PR + label + stop, a human
       # merges from the phone. Auto-merge only when the repo opted in AND the

--- a/playbooks/individual/agentbox/agentbox.yaml
+++ b/playbooks/individual/agentbox/agentbox.yaml
@@ -179,7 +179,26 @@
       owner: "{{ user }}"
       group: "{{ user }}"
       mode: '0755'
-    loop: "{{ [home + '/repos', home + '/.config/opencode', home + '/.config/opencode/skills', home + '/.config/opencode/commands', home + '/.config/agentbox', home + '/.claude', home + '/.claude/skills', home + '/.claude/commands'] + (agentbox_rc_repos | map('regex_replace', '^', home + '/repos/') | list) }}"
+    loop: "{{ [home + '/repos', home + '/work', home + '/agent-logs', home + '/.config/opencode', home + '/.config/opencode/skills', home + '/.config/opencode/commands', home + '/.config/agentbox', home + '/.claude', home + '/.claude/skills', home + '/.claude/commands'] + (agentbox_rc_repos | map('regex_replace', '^', home + '/repos/') | list) }}"
+
+  # --- git config for the agent lanes (commit identity + token-backed https) ---
+  - name: Set git commit identity for the agent user
+    ansible.builtin.command: "git config --global {{ item.k }} \"{{ item.v }}\""
+    become_user: "{{ user }}"
+    environment:
+      HOME: "{{ home }}"
+    loop:
+      - { k: user.name, v: agentbox }
+      - { k: user.email, v: agentbox@terrac.com }
+    changed_when: false
+
+  - name: Register gh as the git credential helper (authenticated https)
+    ansible.builtin.command: gh auth setup-git
+    become_user: "{{ user }}"
+    environment:
+      HOME: "{{ home }}"
+      GH_TOKEN: "{{ (agentbox | default({})).github_pat | default('') }}"
+    changed_when: false
 
   # --- Config + secrets ---
   - name: Render opencode config


### PR DESCRIPTION
Running the autonomous loop end-to-end for the first time (photonic_inventory#1 -> #2) surfaced five plumbing bugs in the base watcher, plus this adds the Claude-reviews-the-draft step you asked for.

## Fixes
1. **Labels** — `ensure_labels()` idempotently `gh label create`s agent-working / needs-claude / needs-human-merge per repo. `gh issue edit --add-label` errors if the label doesn't exist.
2. **git auth** — `gh auth setup-git` in the playbook registers gh as git's credential helper so `git fetch/push` use the token (was: `could not read Username for github.com`).
3. **git identity** — `git config --global user.name/email` for the agent user (was: `Author identity unknown`, commit failed).
4. **Work-dir collision (#15)** — watcher + escalate now clone into `work/<repo>` instead of `repos/<repo>`, which the RC sessions own as cwd. No more collision between the watcher and a live remote-control session.
5. **Draft-log artifact** — opencode's log goes to `agent-logs/` outside the worktree, so `git add -A` never commits `.agent-N.log` into the PR (it did on #2).

## New: premium-lane review
After the watcher opens a PR, the **Claude subscription lane** (independent, stronger model than the Gemini drafter) reviews the diff and posts a comment via `gh pr comment`. Fixed-cost (Agent SDK credit), in-network, diff passed in the prompt so no extra tool permissions. The issue still lands at `needs-human-merge` — review only informs your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)