### PR TITLE
fix(ci): pass commit message/author via env in main-apply (injection)

### DIFF
--- a/.github/workflows/main-apply.yml
+++ b/.github/workflows/main-apply.yml
@@ -143,6 +143,11 @@ jobs:
         env:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
           EXTRA_VARS: ${{ inputs.extra_vars || '' }}
+          # Pass untrusted commit fields via env, never inline ${{ }} in run: —
+          # a commit message with quotes/backticks/$() would otherwise break the
+          # script or inject shell. (PR #43 did this for the per-project deploys.)
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: |
           export PATH="$HOME/.local/bin:$PATH"
 
@@ -160,8 +165,8 @@ jobs:
           echo "================================================"
           echo ""
           echo "Commit: ${{ github.sha }}"
-          echo "Author: ${{ github.event.head_commit.author.name }}"
-          echo "Message: ${{ github.event.head_commit.message }}"
+          echo "Author: $COMMIT_AUTHOR"
+          echo "Message: $COMMIT_MESSAGE"
           echo ""
 
           # Initialize counters
@@ -244,6 +249,9 @@ jobs:
 
       - name: Generate deployment summary
         if: always()
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: |
           TOTAL="${{ steps.apply.outputs.total }}"
           PASSED="${{ steps.apply.outputs.passed }}"
@@ -260,9 +268,9 @@ jobs:
 
           ## $STATUS
 
-          **Commit:** \`${{ github.sha }}\`  
-          **Author:** ${{ github.event.head_commit.author.name }}  
-          **Message:** ${{ github.event.head_commit.message }}  
+          **Commit:** \`${{ github.sha }}\`
+          **Author:** $COMMIT_AUTHOR
+          **Message:** $COMMIT_MESSAGE
           **Playbooks Applied:** $TOTAL  
           **Successful:** $PASSED  
           **Failed:** $FAILED


### PR DESCRIPTION
Follow-up to #43. `main-apply.yml` still interpolated `${{ github.event.head_commit.message }}` and `.author.name` directly into `run:` blocks (apply step + deployment summary), which breaks on commit messages containing quotes and is a script-injection vector. #43 fixed the per-project deploy workflows but not this one — the workflow we run on every push.

Moved both untrusted fields into step `env:` and reference them as `$COMMIT_MESSAGE` / `$COMMIT_AUTHOR`, matching #43's pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)