### PR TITLE
fix(ci): repair ci-validate.yml YAML (dead since e809d75)

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -88,9 +88,7 @@ jobs:
           # `hosts` key or an `*import_playbook` key (FQCN ansible.builtin.import_playbook
           # is the house style, so match the suffix, not the bare name).
           is_playbook() {
-            python3 -c "import yaml,sys
-d=yaml.safe_load(open(sys.argv[1]))
-sys.exit(0 if isinstance(d,list) and d and all(isinstance(i,dict) and any(k=='hosts' or k.endswith('import_playbook') for k in i) for i in d) else 1)" "$1"
+            python3 -c "import yaml,sys; d=yaml.safe_load(open(sys.argv[1])); sys.exit(0 if isinstance(d,list) and d and all(isinstance(i,dict) and any(k=='hosts' or k.endswith('import_playbook') for k in i) for i in d) else 1)" "$1"
           }
 
           echo "Validating Ansible playbook syntax..."


### PR DESCRIPTION
The whole `ci-validate.yml` workflow has been failing at **parse time** — GitHub's "this run likely failed because of a workflow file issue", zero jobs — since commit e809d75. The `is_playbook` helper's inline python put its continuation lines (`d=...`, `sys.exit(...)`) at column 1, outside the `run: |` block scalar, making the YAML invalid.

Net effect: the entire validator suite (YAML syntax, playbook `--syntax-check`, ansible-lint, Jinja2, security scan, vault verify) **has not run on any PR or push since that commit** — that's the wall of red X's.

Fix: collapse the python to a single line (block scalars require indentation; python top-level statements can't be indented). Verified the workflow now parses and `is_playbook` still classifies correctly (terminalbench_model.yaml skipped, real plays checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)