### PR TITLE
revert(llamacpp): roll back to Qwen3-14B (Qwen3.6 arch unsupported)

### DIFF
--- a/files/llamacpp/docker-compose.yml.j2
+++ b/files/llamacpp/docker-compose.yml.j2
@@ -28,34 +28,27 @@ services:
       - {{ home }}/config:/config
       - {{ home }}/logs:/logs
     
-    # RTX 3090: Qwen3.6-35B-A3B (MoE, ~3B active) for agentic coding + tool use.
-    # ~18GB model + q8_0 KV @ 32K fits the 24GB card. --jinja loads the model's
-    # tool-call chat template (required for tool-calling). Verify at deploy:
-    # CUDA 12.8+ in the image (13.2 reportedly produces gibberish); sanity-test
-    # a tool round-trip before trusting it in the agent loop.
-    command:
+    # RTX 3090 Optimized: Qwen3-14B for single-user reasoning with max context
+    # Model: 8.5GB + ~7GB KV cache = fits in 16GB VRAM budget
+    # Supports /think mode for step-by-step reasoning
+    command: 
       - "--host"
       - "0.0.0.0"
-      - "--port"
+      - "--port" 
       - "{{ port }}"
       - "--model"
-      - "/models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+      - "/models/Qwen3-14B-Q4_K_M.gguf"
       - "--n-gpu-layers"
-      - "-1"
+      - "41"
       - "--ctx-size"
-      - "32768"
-      - "--parallel"
+      - "40960"
+      - "--parallel" 
       - "1"
       - "--batch-size"
       - "2048"
-      - "--ubatch-size"
+      - "--ubatch-size" 
       - "512"
       - "--flash-attn"
-      - "--cache-type-k"
-      - "q8_0"
-      - "--cache-type-v"
-      - "q8_0"
-      - "--jinja"
       - "--api-key-file"
       - "/config/keys.txt"
       # API only — the built-in chat UI at / is unauthenticated, so disable

--- a/vars/vars_llamacpp_models.yaml
+++ b/vars/vars_llamacpp_models.yaml
@@ -3,21 +3,6 @@
 
 llamacpp_models:
   reasoning:
-    # Active model: MoE 35B / ~3B active, native tool-calling, ~100 tok/s on a
-    # 3090. IQ4_NL (18GB) over Q4_K_M (22.1GB) to leave VRAM for q8_0 KV @ 32K.
-    # Verify HF card + a coding leaderboard at deploy (released 2026-04-15).
-    - name: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
-      url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
-      size: "18GB"
-      parameters: "35B-A3B (MoE, ~3B active)"
-      vram_usage: "~18GB + q8_0 KV cache (fits 24GB)"
-      capabilities: ["agentic-coding", "tool-calling", "reasoning", "thinking", "repo-level"]
-      context_size: "32K"
-      timeout: 7200
-      priority: 1
-      requires_auth: false
-      benchmark_eligible: true
-
     - name: "Qwen3-14B-Q4_K_M.gguf"
       url: "https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
       size: "8.5GB"
@@ -26,7 +11,7 @@ llamacpp_models:
       capabilities: ["reasoning", "thinking", "step-by-step", "analysis", "math", "coding"]
       context_size: "40K"
       timeout: 3600
-      priority: 3
+      priority: 1
       requires_auth: false
       benchmark_eligible: true
 
@@ -57,18 +42,6 @@ llamacpp_models:
 
 # RTX 3090 Performance Profiles (16GB VRAM budget for headroom)
 rtx_3090_profiles:
-  # Active profile. q8_0 KV (needs flash-attn) keeps 32K context inside 24GB
-  # alongside the 18GB model. --jinja enables the model's tool-call template.
-  single_user_agentic:
-    model: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
-    gpu_layers: -1
-    context_size: 32768
-    batch_size: 2048
-    parallel_requests: 1
-    flash_attention: true
-    thinking_mode: true
-    cache_type: q8_0
-
   single_user_reasoning:
     model: "Qwen3-14B-Q4_K_M.gguf"
     gpu_layers: -1
@@ -97,7 +70,6 @@ rtx_3090_profiles:
 
 # Model download priorities (1 = download first)
 download_priority:
-  1: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+  1: "Qwen3-14B-Q4_K_M.gguf"
   2: "Qwen3-8B-Q4_K_M.gguf"
-  3: "Qwen3-14B-Q4_K_M.gguf"
-  4: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"
+  3: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"


### PR DESCRIPTION
Qwen3.6-35B-A3B uses architecture `qwen35moe` (hybrid MoE + SSM), which the current `ghcr.io/ggerganov/llama.cpp:server-cuda` image does not support — `unknown model architecture: 'qwen35moe'`, llama-server segfaults (exit 139) crash-looping. The local lane / llama.home was down. Reverting #50 to restore Qwen3-14B (still on disk, fast recovery).

Re-attempt requires bumping llama.cpp to a build with qwen35moe support (verify it exists first) — tracked separately, not now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)