### PR TITLE
feat(llamacpp): Qwen3.6-35B-A3B on ggml-org image (qwen35moe support)

### DIFF
--- a/files/llamacpp/docker-compose.yml.j2
+++ b/files/llamacpp/docker-compose.yml.j2
@@ -28,27 +28,34 @@ services:
       - {{ home }}/config:/config
       - {{ home }}/logs:/logs
     
-    # RTX 3090 Optimized: Qwen3-14B for single-user reasoning with max context
-    # Model: 8.5GB + ~7GB KV cache = fits in 16GB VRAM budget
-    # Supports /think mode for step-by-step reasoning
-    command: 
+    # RTX 3090: Qwen3.6-35B-A3B (MoE, ~3B active) for agentic coding + tool use.
+    # ~18GB model + q8_0 KV @ 32K fits the 24GB card. --jinja loads the model's
+    # tool-call chat template (required for tool-calling). Verify at deploy:
+    # CUDA 12.8+ in the image (13.2 reportedly produces gibberish); sanity-test
+    # a tool round-trip before trusting it in the agent loop.
+    command:
       - "--host"
       - "0.0.0.0"
-      - "--port" 
+      - "--port"
       - "{{ port }}"
       - "--model"
-      - "/models/Qwen3-14B-Q4_K_M.gguf"
+      - "/models/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
       - "--n-gpu-layers"
-      - "41"
+      - "-1"
       - "--ctx-size"
-      - "40960"
-      - "--parallel" 
+      - "32768"
+      - "--parallel"
       - "1"
       - "--batch-size"
       - "2048"
-      - "--ubatch-size" 
+      - "--ubatch-size"
       - "512"
       - "--flash-attn"
+      - "--cache-type-k"
+      - "q8_0"
+      - "--cache-type-v"
+      - "q8_0"
+      - "--jinja"
       - "--api-key-file"
       - "/config/keys.txt"
       # API only — the built-in chat UI at / is unauthenticated, so disable

--- a/playbooks/individual/ocean/ai/llamacpp.yaml
+++ b/playbooks/individual/ocean/ai/llamacpp.yaml
@@ -11,7 +11,10 @@
 
   vars:
     service: llamacpp
-    image: ghcr.io/ggerganov/llama.cpp
+    # ggml-org is the maintained org (ggerganov/* is frozen post-rename and too
+    # old for newer archs, e.g. Qwen3.6's qwen35moe). Verified loading Qwen3.6
+    # on server-cuda before this bump.
+    image: ghcr.io/ggml-org/llama.cpp
     version: server-cuda
     port: "{{ service_ports.llamacpp.port }}"  # noqa: var-naming[no-reserved]
     data: /data01

--- a/vars/vars_llamacpp_models.yaml
+++ b/vars/vars_llamacpp_models.yaml
@@ -3,6 +3,21 @@
 
 llamacpp_models:
   reasoning:
+    # Active model: MoE 35B / ~3B active, native tool-calling, ~100 tok/s on a
+    # 3090. IQ4_NL (18GB) over Q4_K_M (22.1GB) to leave VRAM for q8_0 KV @ 32K.
+    # Verify HF card + a coding leaderboard at deploy (released 2026-04-15).
+    - name: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+      url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+      size: "18GB"
+      parameters: "35B-A3B (MoE, ~3B active)"
+      vram_usage: "~18GB + q8_0 KV cache (fits 24GB)"
+      capabilities: ["agentic-coding", "tool-calling", "reasoning", "thinking", "repo-level"]
+      context_size: "32K"
+      timeout: 7200
+      priority: 1
+      requires_auth: false
+      benchmark_eligible: true
+
     - name: "Qwen3-14B-Q4_K_M.gguf"
       url: "https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
       size: "8.5GB"
@@ -11,7 +26,7 @@ llamacpp_models:
       capabilities: ["reasoning", "thinking", "step-by-step", "analysis", "math", "coding"]
       context_size: "40K"
       timeout: 3600
-      priority: 1
+      priority: 3
       requires_auth: false
       benchmark_eligible: true
 
@@ -42,6 +57,18 @@ llamacpp_models:
 
 # RTX 3090 Performance Profiles (16GB VRAM budget for headroom)
 rtx_3090_profiles:
+  # Active profile. q8_0 KV (needs flash-attn) keeps 32K context inside 24GB
+  # alongside the 18GB model. --jinja enables the model's tool-call template.
+  single_user_agentic:
+    model: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
+    gpu_layers: -1
+    context_size: 32768
+    batch_size: 2048
+    parallel_requests: 1
+    flash_attention: true
+    thinking_mode: true
+    cache_type: q8_0
+
   single_user_reasoning:
     model: "Qwen3-14B-Q4_K_M.gguf"
     gpu_layers: -1
@@ -70,6 +97,7 @@ rtx_3090_profiles:
 
 # Model download priorities (1 = download first)
 download_priority:
-  1: "Qwen3-14B-Q4_K_M.gguf"
+  1: "Qwen3.6-35B-A3B-UD-IQ4_NL.gguf"
   2: "Qwen3-8B-Q4_K_M.gguf"
-  3: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"
+  3: "Qwen3-14B-Q4_K_M.gguf"
+  4: "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"


### PR DESCRIPTION
Re-does the Qwen3.6 upgrade (#50, reverted in #66) the right way: the failure was the **image**, not the model. `ghcr.io/ggerganov/llama.cpp` is frozen after the ggml-org rename and too old for Qwen3.6's `qwen35moe` architecture (`unknown model architecture` -> segfault). Bumped to `ghcr.io/ggml-org/llama.cpp:server-cuda`.

**Verified before merging:** pulled the ggml-org image on ocean and test-loaded `Qwen3.6-35B-A3B-UD-IQ4_NL.gguf` — `model loaded` / `listening`, no arch error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)