### PR TITLE
fix(llamacpp): --flash-attn needs explicit 'on' (crash-loop fix)

### DIFF
--- a/files/llamacpp/docker-compose.yml.j2
+++ b/files/llamacpp/docker-compose.yml.j2
@@ -51,6 +51,7 @@ services:
       - "--ubatch-size"
       - "512"
       - "--flash-attn"
+      - "on"
       - "--cache-type-k"
       - "q8_0"
       - "--cache-type-v"


### PR DESCRIPTION
Live llamacpp is crash-looping on the ggml-org image: `--flash-attn` is now a valued flag (`on|off|auto`); passed bare it eats `--cache-type-k` and fails to parse. One-line fix.