### PR TITLE
feat(alerting): slice 3 — critical -> immediate RC remediation

### DIFF
--- a/files/agentbox/agentbox-alert-receiver.service.j2
+++ b/files/agentbox/agentbox-alert-receiver.service.j2
@@ -13,6 +13,9 @@ EnvironmentFile=-{{ home }}/.config/agentbox/agentbox.env
 Environment=ALERT_NTFY_URL={{ alert_ntfy_url }}
 Environment=ALERT_ISSUE_REPO={{ alert_issue_repo }}
 Environment=ALERT_LISTEN_PORT={{ alert_receiver_port }}
+# Critical alerts kick agentbox-escalate-to-claude.sh for an immediate premium-
+# lane fix PR. Set 0 to disable unattended infra edits (issue + ntfy still fire).
+Environment=ALERT_REMEDIATE=1
 ExecStart=/usr/bin/python3 /usr/local/bin/agentbox-alert-receiver.py
 Restart=on-failure
 RestartSec=10

--- a/files/agentbox/alert-receiver.py
+++ b/files/agentbox/alert-receiver.py
@@ -22,15 +22,22 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 NTFY_URL = os.environ["ALERT_NTFY_URL"]           # e.g. http://ntfy.home:8090/homelab
 ISSUE_REPO = os.environ["ALERT_ISSUE_REPO"]       # e.g. bluefishforsale/homelab
 LISTEN_PORT = int(os.environ.get("ALERT_LISTEN_PORT", "9098"))
+# Critical alerts kick an immediate premium-lane remediation. Set 0 to disable
+# unattended infra edits (issue + ntfy still fire).
+REMEDIATE = os.environ.get("ALERT_REMEDIATE", "1") == "1"
+RC_URL = os.environ.get("ALERT_RC_URL", "https://claude.ai/code")  # live RC console
+ESCALATE = "/usr/local/bin/agentbox-escalate-to-claude.sh"
+REPO_NAME = ISSUE_REPO.split("/")[-1]
 FP_MARKER = "alert-fp:"  # embedded in the issue body to dedupe by fingerprint
 
 PRIO = {"critical": "urgent", "warning": "high", "info": "default"}
 
 
-def ntfy(title, message, priority="default", tags=""):
-    req = urllib.request.Request(
-        NTFY_URL, data=message.encode(),
-        headers={"Title": title, "Priority": priority, "Tags": tags})
+def ntfy(title, message, priority="default", tags="", click=""):
+    headers = {"Title": title, "Priority": priority, "Tags": tags}
+    if click:
+        headers["Click"] = click
+    req = urllib.request.Request(NTFY_URL, data=message.encode(), headers=headers)
     try:
         urllib.request.urlopen(req, timeout=10).read()
     except Exception as e:  # awareness is best-effort; never crash the receiver
@@ -54,11 +61,13 @@ def issue_exists(fp):
 
 
 def open_issue(alert):
+    """Create (or reuse) the tracking issue; return its number, or None if it
+    already exists / creation failed."""
     labels = alert["labels"]
     ann = alert.get("annotations", {})
     fp = alert.get("fingerprint", labels.get("alertname", "unknown"))
     if issue_exists(fp):
-        return
+        return None
     sev = labels.get("severity", "warning")
     name = labels.get("alertname", "alert")
     inst = labels.get("instance", labels.get("job", ""))
@@ -74,7 +83,28 @@ def open_issue(alert):
            "--color", "5319E7", "--force")  # idempotent; ignore result
         args += ["--label", "needs-claude"]
     r = gh(*args)
-    print((r.stdout or r.stderr).strip(), flush=True)
+    out = (r.stdout or r.stderr).strip()
+    print(out, flush=True)
+    if r.returncode != 0:
+        return None
+    try:
+        return int(out.rsplit("/", 1)[-1])  # gh prints the new issue URL
+    except ValueError:
+        return None
+
+
+def remediate(num):
+    """Kick an immediate premium-lane fix for a critical alert. Detached so a
+    multi-minute claude run never blocks the HTTP handler; it only ever opens a
+    PR (never auto-merges infra), so a human still gates the change.
+    ponytail: child dies if the receiver service restarts mid-run (cgroup kill);
+    acceptable — the needs-claude issue survives and the periodic drain retries.
+    """
+    if not os.path.exists(ESCALATE):
+        print(f"escalate script missing: {ESCALATE}", flush=True)
+        return
+    print(f"remediating critical alert via issue #{num}", flush=True)
+    subprocess.Popen([ESCALATE, REPO_NAME, str(num)], start_new_session=True)
 
 
 def handle(payload):
@@ -87,9 +117,16 @@ def handle(payload):
         # NB: emoji must go in Tags (ntfy renders them), never the Title header —
         # HTTP headers are latin-1 and non-ASCII there raises.
         if alert.get("status") == "firing":
-            ntfy(f"{name} ({sev})", f"{inst}\n{summary}".strip(),
-                 PRIO.get(sev, "default"), "rotating_light,homelab")
-            open_issue(alert)
+            num = open_issue(alert)
+            issue_url = f"https://github.com/{ISSUE_REPO}/issues/{num}" if num else ""
+            body = "\n".join(x for x in (inst, summary, issue_url) if x)
+            # Critical: one-tap into the live RC console to supervise; warning:
+            # tap opens the tracking issue.
+            ntfy(f"{name} ({sev})", body, PRIO.get(sev, "default"),
+                 "rotating_light,homelab",
+                 click=RC_URL if sev == "critical" else issue_url)
+            if num and sev == "critical" and REMEDIATE:
+                remediate(num)
         else:
             ntfy(f"resolved: {name}", f"{inst}\n{summary}".strip(),
                  "min", "white_check_mark,homelab")

--- a/files/agentbox/escalate-to-claude.sh
+++ b/files/agentbox/escalate-to-claude.sh
@@ -42,51 +42,68 @@ no_prod_effect() {  # $1 = newline-separated changed files
   return 0
 }
 
-for repo in ${AGENTBOX_REPOS:-}; do
-  slug="$OWNER/$repo"
+resolve_issue() {  # $1 = repo (short name); $2 = issue number
+  local repo="$1" num="$2" slug="$OWNER/$1"
   # Per-repo/per-lane telemetry labels for everything claude emits this pass.
   export OTEL_RESOURCE_ATTRIBUTES="repo=$repo,lane=claude,service=agentbox"
   ensure_labels "$slug"
-  issues=$(gh issue list --repo "$slug" --state open --label "$LABEL_CLAUDE" \
-    --json number --jq '.[].number') || continue
 
-  for num in $issues; do
-    title=$(gh issue view "$num" --repo "$slug" --json title --jq .title)
-    body=$(gh issue view "$num" --repo "$slug" --json body --jq .body)
-    gh issue edit "$num" --repo "$slug" \
-      --remove-label "$LABEL_CLAUDE" --add-label "$LABEL_WORKING" >/dev/null
+  local title body
+  title=$(gh issue view "$num" --repo "$slug" --json title --jq .title)
+  body=$(gh issue view "$num" --repo "$slug" --json body --jq .body)
+  gh issue edit "$num" --repo "$slug" \
+    --remove-label "$LABEL_CLAUDE" --add-label "$LABEL_WORKING" >/dev/null 2>&1 || true
 
-    wt="$WORKROOT/$repo"
-    [ -d "$wt/.git" ] || gh repo clone "$slug" "$wt" -- -q
-    git -C "$wt" fetch -q origin
-    git -C "$wt" checkout -q -B "agent/issue-$num" origin/HEAD
+  local wt="$WORKROOT/$repo"
+  [ -d "$wt/.git" ] || gh repo clone "$slug" "$wt" -- -q
+  git -C "$wt" fetch -q origin
+  git -C "$wt" checkout -q -B "agent/issue-$num" origin/HEAD
 
-    prompt="Resolve GitHub issue #$num: $title
+  local prompt="Resolve GitHub issue #$num: $title
 
 $body
 
 Make the minimal, correct change; keep the build and tests green."
 
-    # Worktrees are cloned on the fly; trust each before claude reads it
-    # (no flag for the workspace-trust gate).
-    /usr/local/bin/agentbox-trust-dir.sh "$wt" || true
-    (cd "$wt" && claude -p "$prompt" --permission-mode acceptEdits) || true
+  # Worktrees are cloned on the fly; trust each before claude reads it
+  # (no flag for the workspace-trust gate).
+  /usr/local/bin/agentbox-trust-dir.sh "$wt" || true
+  (cd "$wt" && claude -p "$prompt" --permission-mode acceptEdits) || true
 
-    if [ -n "$(git -C "$wt" status --porcelain)" ]; then
-      git -C "$wt" add -A
-      git -C "$wt" commit -q -m "fix: resolve #$num ($title)"
-      git -C "$wt" push -q -u origin "agent/issue-$num"
-      gh pr create --repo "$slug" --head "agent/issue-$num" \
-        --title "fix: $title (#$num)" \
-        --body "Resolves #$num. Shipped by the Claude Code premium lane." || true
+  [ -n "$(git -C "$wt" status --porcelain)" ] || return 0
+  git -C "$wt" add -A
+  git -C "$wt" commit -q -m "fix: resolve #$num ($title)"
+  git -C "$wt" push -q -u origin "agent/issue-$num"
+  gh pr create --repo "$slug" --head "agent/issue-$num" \
+    --title "fix: $title (#$num)" \
+    --body "Resolves #$num. Shipped by the Claude Code premium lane." || true
 
-      changed=$(git -C "$wt" diff --name-only origin/HEAD...HEAD)
-      if printf ' %s ' "${AGENTBOX_AUTOMERGE_REPOS:-}" | grep -q " $repo " \
-         && no_prod_effect "$changed"; then
-        gh pr merge --repo "$slug" --auto --squash "agent/issue-$num" || true
-      else
-        gh issue edit "$num" --repo "$slug" --add-label "$LABEL_REVIEW" >/dev/null || true
-      fi
-    fi
+  local changed
+  changed=$(git -C "$wt" diff --name-only origin/HEAD...HEAD)
+  if printf ' %s ' "${AGENTBOX_AUTOMERGE_REPOS:-}" | grep -q " $repo " \
+     && no_prod_effect "$changed"; then
+    gh pr merge --repo "$slug" --auto --squash "agent/issue-$num" || true
+  else
+    gh issue edit "$num" --repo "$slug" --add-label "$LABEL_REVIEW" >/dev/null || true
+  fi
+}
+
+# Triggered single-issue mode: `escalate-to-claude.sh <repo> <issue#>`. Used by
+# the alert receiver for immediate critical-alert remediation, and it works for
+# ANY repo (the infra repo is deliberately absent from AGENTBOX_REPOS, so the
+# periodic drain below never touches it). Never auto-merges unless the repo is
+# opted into AGENTBOX_AUTOMERGE_REPOS — homelab isn't, so it opens a PR a human
+# merges, the correct autonomy tier for infra (ADR 0001).
+if [ "$#" -ge 2 ]; then
+  resolve_issue "$1" "$2"
+  exit 0
+fi
+
+# Periodic drain: every needs-claude issue across the deployable repos.
+for repo in ${AGENTBOX_REPOS:-}; do
+  issues=$(gh issue list --repo "$OWNER/$repo" --state open --label "$LABEL_CLAUDE" \
+    --json number --jq '.[].number') || continue
+  for num in $issues; do
+    resolve_issue "$repo" "$num"
   done
 done


### PR DESCRIPTION
Critical alerts now trigger an immediate premium-lane fix PR (escalate single-issue mode) + one-tap RC console link, in addition to the needs-claude issue. Never auto-merges infra. `ALERT_REMEDIATE=0` kill-switch. Smoke-tested: critical->RC click+remediate, warning->issue click only.