### PR TITLE
fix(base): wire authorized_keys refresh timer into base-system + VM next-steps

### DIFF
--- a/playbooks/01_base_system.yaml
+++ b/playbooks/01_base_system.yaml
@@ -15,6 +15,9 @@
 - name: Configure System Users and Groups
   ansible.builtin.import_playbook: individual/base/users.yaml
 
+- name: Install authorized_keys refresh timer
+  ansible.builtin.import_playbook: individual/base/authorized_keys.yaml
+
 - name: Configure Timezone, Sysctl, and Udev
   ansible.builtin.import_playbook: individual/base/tz_sysctl_udev.yaml
 

--- a/playbooks/individual/infrastructure/create_agentbox_vm.yaml
+++ b/playbooks/individual/infrastructure/create_agentbox_vm.yaml
@@ -121,5 +121,6 @@
           - ""
           - "Next steps:"
           - "1. agentbox is already in inventory under [vms] and [agentbox]"
-          - "2. Deploy the host config: ansible-playbook playbooks/individual/agentbox/agentbox.yaml"
-          - "3. One-time manual auth on the box (see playbook header): claude /login, gh auth login, gcloud auth"
+          - "2. Apply base system (users + authorized_keys refresh timer): ansible-playbook playbooks/01_base_system.yaml --limit agentbox"
+          - "3. Deploy the host config: ansible-playbook playbooks/individual/agentbox/agentbox.yaml"
+          - "4. One-time manual auth on the box (see playbook header): claude /login, gh auth login, gcloud auth"

--- a/playbooks/individual/infrastructure/create_registry_cache_vm.yaml
+++ b/playbooks/individual/infrastructure/create_registry_cache_vm.yaml
@@ -114,4 +114,5 @@
           - ""
           - "Next steps:"
           - "1. Confirm {{ cache_vm_hostname }} is under [registry_cache] in inventories/production/hosts.ini"
-          - "2. Run: ansible-playbook playbooks/individual/infrastructure/registry_cache.yaml"
+          - "2. Apply base system (users + authorized_keys refresh timer): ansible-playbook playbooks/01_base_system.yaml --limit {{ cache_vm_hostname }}"
+          - "3. Run: ansible-playbook playbooks/individual/infrastructure/registry_cache.yaml"

--- a/playbooks/individual/infrastructure/create_runner_vm.yaml
+++ b/playbooks/individual/infrastructure/create_runner_vm.yaml
@@ -116,5 +116,6 @@
           - ""
           - "Next steps:"
           - "1. Add {{ runner_vm_hostname }} to your inventory under [github_runners] group"
-          - "2. Configure group_vars/github_runners.yml with GitHub token and settings"
-          - "3. Run: ansible-playbook github-docker-runners.yml"
+          - "2. Apply base system (users + authorized_keys refresh timer): ansible-playbook playbooks/01_base_system.yaml --limit {{ runner_vm_hostname }}"
+          - "3. Configure group_vars/github_runners.yml with GitHub token and settings"
+          - "4. Run: ansible-playbook github-docker-runners.yml"


### PR DESCRIPTION
authorized_keys.yaml (installs the 5-min refresh-authorized-keys timer) was orphaned, wired into no flow. New VMs got keys once via cloud-init `--sshkeys` and never got the timer or the terrac/media/root key setup.

- Import it into `01_base_system.yaml` after `users.yaml`.
- Add an 'apply base system' step to the three `create_*_vm.yaml` Next-steps so the setup isn't skipped on the jump to the service playbook.

Playbook edits only, no behavior change until base-system is applied.

Out of scope (backlog): dns01/dns02/pi_hole create playbooks set no `--sshkeys` at all; base-system still runs manually after VM creation.