### PR TITLE
fix(base): install sudo so /etc/sudoers exists before sudoers edit

### DIFF
--- a/playbooks/individual/base/users.yaml
+++ b/playbooks/individual/base/users.yaml
@@ -22,6 +22,7 @@
         - zsh
         - git
         - cron
+        - sudo
       ignore_errors: yes
 
     # Define user details with centralized uid/gid from vault


### PR DESCRIPTION
`users.yaml` adds passwordless `/etc/sudoers` entries via `lineinfile` but only installed zsh/git/cron. Proxmox nodes and minimal Debian cloud-init VMs ship no `sudo` package, so `/etc/sudoers` is absent and `lineinfile` aborts (rc 257) on every host — killing `01_base_system` before the users and authorized_keys timer setup could run.

Surfaced by #107's deploy: base-system failed fleet-wide on this task, so the authorized_keys play never ran. Add `sudo` to the install list to fix the root cause.