### PR TITLE
fix(base): pre-create docker group before adding users to it

### DIFF
--- a/playbooks/individual/base/users.yaml
+++ b/playbooks/individual/base/users.yaml
@@ -44,6 +44,14 @@
         loop_var: user
       when: user.gid is defined
 
+    # Users are added to the docker group below, but docker (and its group)
+    # is installed by a later playbook. Pre-create the group so user creation
+    # doesn't fail on fresh hosts; docker's postinst reuses an existing group.
+    - name: Ensure docker group exists
+      ansible.builtin.group:
+        name: docker
+        state: present
+
     - name: Ensure the user exists with specified UIDs/GIDs
       ansible.builtin.user:
         name: "{{ user.user_name }}"


### PR DESCRIPTION
users.yaml adds every non-root user to `sudo,docker`, but the ansible `user` module fails if a listed group is missing. docker (and its group) is installed by a later playbook, so on fresh VMs the group is absent and user creation aborts `01_base_system` before the authorized_keys play runs.

Second layer of the same pre-existing breakage surfaced by #107's deploy (first was `/etc/sudoers` missing, fixed in #108). Pre-create the docker group; docker's postinst reuses an existing group. Closes the loop so `01_base_system` completes on fresh VM creations.