### PR TITLE
fix(base): stop managing debian login user in users.yaml

### DIFF
--- a/playbooks/individual/base/users.yaml
+++ b/playbooks/individual/base/users.yaml
@@ -31,7 +31,8 @@
         users:
           - { user_name: "media", user_home: "/home/media", uid: "{{ system_users.media.uid }}", gid: "{{ system_users.media.gid }}" }
           - { user_name: "terrac", user_home: "/home/terrac", uid: "{{ system_users.terrac.uid }}", gid: "{{ system_users.terrac.gid }}" }
-          - { user_name: "debian", user_home: "/home/debian", uid: "{{ system_users.debian.uid }}", gid: "{{ system_users.debian.gid }}" }
+          # 'debian' is the cloud-init login user Ansible connects as on VMs;
+          # usermod can't modify an in-use account, so it is not managed here.
           - { user_name: "root", user_home: "/root" }
 
     - name: Ensure user groups exist with specified GIDs


### PR DESCRIPTION
On VMs Ansible connects as the cloud-init `debian` user; the user module then fails `usermod: user debian is currently used by process` because it can't modify the in-use login account. That aborted `01_base_system` before the authorized_keys play.

Third and final layer of the pre-existing users.yaml breakage surfaced by #107 (after #108 sudo, #109 docker group). Drop debian from the managed users list — it stays the cloud-init user as-is, and its authorized_keys refresh is handled by the standalone authorized_keys timer.