### PR TITLE
fix(open-webui): reconcile DB-persisted llamacpp key to vault

### DIFF
--- a/playbooks/individual/ocean/ai/open_webui.yaml
+++ b/playbooks/individual/ocean/ai/open_webui.yaml
@@ -105,6 +105,37 @@
       timeout: 60
     ignore_errors: yes
 
+  # Open WebUI's PersistentConfig freezes OPENAI_API_KEYS into webui.db on
+  # first boot; after that the env var is ignored and the stored value wins.
+  # Reconcile the stored key to the vault so key changes actually take effect.
+  - name: Reconcile stored llama.cpp API key in open-webui DB
+    ansible.builtin.command:
+      argv:
+        - docker
+        - exec
+        - "-e"
+        - "NEW_KEY={{ ai_services.llamacpp.api_keys.openwebui }}"
+        - "{{ service }}"
+        - python3
+        - "-c"
+        - |
+          import sqlite3, json, os
+          desired = json.dumps([os.environ["NEW_KEY"]])
+          conn = sqlite3.connect("/data/webui.db")
+          row = conn.execute("select value from config where key='openai.api_keys'").fetchone()
+          if row is None:
+              print("NOROW"); raise SystemExit(0)
+          if row[0] == desired:
+              print("OK"); raise SystemExit(0)
+          conn.execute("update config set value=? where key='openai.api_keys'", (desired,))
+          conn.commit()
+          print("CHANGED")
+    register: owui_key_reconcile
+    changed_when: "'CHANGED' in owui_key_reconcile.stdout"
+    no_log: true
+    notify:
+    - Restart open-webui service
+
   handlers:
   - name: Reload systemd daemon
     ansible.builtin.systemd:


### PR DESCRIPTION
Open WebUI's PersistentConfig freezes `OPENAI_API_KEYS` into `webui.db` on first boot; the env var is ignored thereafter. So #111's compose key change never took effect — the app kept sending the old hardcoded `llamacpp-homelab-key` and llama.cpp returned 'Invalid API Key'.

Verified on ocean: `config` table had `openai.api_keys => ["llamacpp-homelab-key"]` despite the container env carrying the correct new key.

Add an idempotent deploy task that updates the stored `openai.api_keys` in `webui.db` to the vault key and restarts only on change, so key changes (and future rotations) actually propagate.