### PR TITLE
fix(base): tolerate in-use login user + skip service users on appliances

### DIFF
--- a/inventories/production/hosts.ini
+++ b/inventories/production/hosts.ini
@@ -13,7 +13,7 @@ node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apc
 ocean ansible_user=terrac ansible_python_interpreter=/usr/bin/python3 ansible_ssh_host=192.168.1.143 bare_metal_host="node006" nvidia_gpu=true
 dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005"
 # gitlab ansible_user=debian ansible_ssh_host=192.168.1.5 bare_metal_host="node005"
-pihole ansible_user=debian ansible_ssh_host=192.168.1.9 bare_metal_host="node005"
+pihole ansible_user=debian ansible_ssh_host=192.168.1.9 bare_metal_host="node005" manage_service_users=false
 gh-runner-01 ansible_user=debian ansible_ssh_host=192.168.1.20 bare_metal_host="node005"
 registry-cache-01 ansible_user=debian ansible_ssh_host=192.168.1.30 bare_metal_host="node005" registry_cache_mirror=false
 dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006"

--- a/playbooks/individual/base/users.yaml
+++ b/playbooks/individual/base/users.yaml
@@ -25,15 +25,18 @@
         - sudo
       ignore_errors: yes
 
-    # Define user details with centralized uid/gid from vault
+    # Define user details with centralized uid/gid from vault.
+    # 'debian' is the cloud-init login user Ansible connects as on VMs;
+    # usermod can't modify an in-use account, so it is not managed here.
+    # Appliance hosts (e.g. pihole) set manage_service_users=false to skip
+    # media/terrac, whose uid/gid collide with pre-existing service accounts.
     - name: Set user details
       set_fact:
-        users:
+        users: "{{ (service_users if (manage_service_users | default(true) | bool) else []) + [{'user_name': 'root', 'user_home': '/root'}] }}"
+      vars:
+        service_users:
           - { user_name: "media", user_home: "/home/media", uid: "{{ system_users.media.uid }}", gid: "{{ system_users.media.gid }}" }
           - { user_name: "terrac", user_home: "/home/terrac", uid: "{{ system_users.terrac.uid }}", gid: "{{ system_users.terrac.gid }}" }
-          # 'debian' is the cloud-init login user Ansible connects as on VMs;
-          # usermod can't modify an in-use account, so it is not managed here.
-          - { user_name: "root", user_home: "/root" }
 
     - name: Ensure user groups exist with specified GIDs
       ansible.builtin.group:
@@ -66,6 +69,13 @@
       loop: "{{ users }}"
       loop_control:
         loop_var: user
+      register: user_result
+      # A managed user that is also the account Ansible logged in as (e.g.
+      # terrac on ocean, uid 1000 vs the vault's 1002) can't be usermod'd while
+      # in use. Tolerate only that case; its uid keeps its existing value.
+      failed_when:
+        - user_result.failed | default(false)
+        - "'is currently used by process' not in (user_result.msg | default(''))"
 
     - name: Add user to sudoers with no password
       ansible.builtin.lineinfile:


### PR DESCRIPTION
Final two pre-existing users.yaml failures (host drift, not VM-creation):

- **ocean**: terrac is the SSH login user at uid 1000 while the vault standard is 1002; `usermod` can't change an in-use account (`rc 8`). Tolerate only that case via `failed_when` so base-system completes — terrac keeps its existing uid, no chown sweep.
- **pihole**: media/terrac don't exist and gid 1001 is squatted by the `pihole` service group. Add `manage_service_users` (default true), set `false` for pihole so it provisions root only.

Both non-disruptive per the chosen strategy.