### PR TITLE
fix(agentbox): self-healing RC lanes (crash/deploy/reboot)

### DIFF
--- a/files/agentbox/agentbox-rc@.service.j2
+++ b/files/agentbox/agentbox-rc@.service.j2
@@ -18,7 +18,9 @@ WorkingDirectory={{ home }}/repos/%i
 # Control?" prompt under a pty (Claude Code has no flag for either). See
 # files/agentbox/rc-launch.sh.
 ExecStart=/usr/local/bin/agentbox-rc-launch.sh %i
-Restart=on-failure
+# always (not on-failure): the RC session can exit 0 on a claude.ai disconnect;
+# bring it back regardless. An intentional `systemctl stop` is still respected.
+Restart=always
 RestartSec=30
 StandardOutput=journal
 StandardError=journal

--- a/playbooks/individual/agentbox/agentbox.yaml
+++ b/playbooks/individual/agentbox/agentbox.yaml
@@ -296,10 +296,11 @@
   # started now: they need the one-time interactive `claude /login` and a clone
   # of each repo into repos/<repo> first (see header). After bootstrap they
   # come up on the next boot or via `systemctl start`.
-  - name: Enable per-repo remote-control instances
+  - name: Enable and start per-repo remote-control instances
     ansible.builtin.systemd:
       name: "agentbox-rc@{{ item }}.service"
       enabled: yes
+      state: started
       daemon_reload: yes
     loop: "{{ agentbox_rc_repos }}"
 
@@ -412,5 +413,8 @@
   # try-restart only touches active instances (no-op before first login), so a
   # shared-config change reloads any live RC session without starting new ones.
   - name: Restart RC sessions
-    ansible.builtin.command: systemctl try-restart 'agentbox-rc@*.service'
+    # restart, not try-restart: try-restart skips units that are stopped/failed,
+    # leaving a dead lane dead. restart revives them so config changes reconcile
+    # every configured lane back up.
+    ansible.builtin.command: systemctl restart 'agentbox-rc@*.service'
     changed_when: true


### PR DESCRIPTION
RC lanes could sit dead indefinitely (photonic_inventory was down 2 days): unit was `Restart=on-failure` (no revive on clean exit/stop), the enable task only set `enabled` (no `state: started`), and the handler used `try-restart` (skips dead units).

- unit `Restart=always` — a lane that exits comes back in 30s
- enable task `state: started` — every deploy/reboot reconciles all lanes up
- handler `restart` not `try-restart` — config changes revive dead lanes

Intentional `systemctl stop` is still respected (systemd doesn't auto-restart after an explicit stop).