### PR TITLE
fix(nzbget): use vault control password in nzbget.conf

### DIFF
--- a/files/ocean-nzbget/config/nzbget.conf.j2
+++ b/files/ocean-nzbget/config/nzbget.conf.j2
@@ -319,7 +319,7 @@ ControlUsername=nzbget
 # Password which NZBGet server and remote client use.
 #
 # Set to empty value to disable authorization request.
-ControlPassword=nzbget
+ControlPassword={{ media_services.nzbget.control_password }}
 
 # User name for restricted access.
 #


### PR DESCRIPTION
nzbget.conf hardcoded `ControlPassword=nzbget` (literal) while nzbget-exporter authenticates with the vault `media_services.nzbget.control_password`. Mismatch → nzbget API **401** → exporter **500** → empty nzbget dashboard.

Verified on ocean: exporter logs `nzbget api response 401 Unauthorized` on every scrape. Username (`nzbget`) already matches both sides; only the password was wrong. Template the vault password into the conf.