### PR TITLE
fix(registry-cache): real pulls + cache-size metric on dashboard

### DIFF
--- a/files/grafana-compose/dashboards/Registry_Cache.json
+++ b/files/grafana-compose/dashboards/Registry_Cache.json
@@ -23,33 +23,57 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 100,
       "panels": [],
       "title": "Cache Performance",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 1,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.5 },
-              { "color": "green", "value": 0.8 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
             ]
           },
-          "unit": "percentunit"
+          "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
         "colorMode": "value",
@@ -57,7 +81,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -66,108 +92,131 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
-          "editorMode": "code",
-          "expr": "sum by (upstream) (rate(registry_proxy_hits_total[5m])) / clamp_min(sum by (upstream) (rate(registry_proxy_hits_total[5m]) + rate(registry_proxy_misses_total[5m])), 0.0001)",
-          "legendFormat": "{{upstream}}",
-          "range": true,
-          "refId": "A"
+          "refId": "A",
+          "expr": "sum(registry_cache_size_bytes)",
+          "legendFormat": "total"
         }
       ],
-      "title": "Cache hit rate (5m)",
+      "title": "Total cache size",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 30,
             "lineWidth": 1,
-            "stacking": { "group": "A", "mode": "normal" },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
             "showPoints": "never"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
-          "unit": "ops"
+          "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
       "id": 2,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
-          "editorMode": "code",
-          "expr": "sum by (upstream) (rate(registry_proxy_hits_total[5m]))",
-          "legendFormat": "{{upstream}} hits",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
-          "editorMode": "code",
-          "expr": "sum by (upstream) (rate(registry_proxy_misses_total[5m]))",
-          "legendFormat": "{{upstream}} misses",
-          "range": true,
-          "refId": "B"
+          "refId": "A",
+          "expr": "registry_cache_size_bytes",
+          "legendFormat": "{{upstream}}"
         }
       ],
-      "title": "Cache hits vs misses",
+      "title": "Cache size by upstream",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
-          "editorMode": "code",
-          "expr": "sum by (upstream) (increase(registry_proxy_hits_total[24h]))",
-          "legendFormat": "{{upstream}} hits 24h",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
-          "editorMode": "code",
-          "expr": "sum by (upstream) (increase(registry_proxy_misses_total[24h]))",
-          "legendFormat": "{{upstream}} misses 24h",
-          "range": true,
-          "refId": "B"
+          "refId": "A",
+          "expr": "sum by (upstream) (increase(registry_http_requests_total{handler=\"manifest\",method=\"get\",code=~\"2..\"}[24h]))",
+          "legendFormat": "{{upstream}}"
         }
       ],
       "title": "Pulls served (24h)",
@@ -175,45 +224,91 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 101,
       "panels": [],
       "title": "Health & Availability",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "red", "text": "DOWN" } }, "type": "value" },
-            { "options": { "1": { "color": "green", "text": "UP" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           }
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
       "id": 4,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "up{job=\"registry-cache\"}",
           "legendFormat": "{{upstream}}",
@@ -226,32 +321,66 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10,
             "lineWidth": 1,
             "showPoints": "never",
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 9, "x": 6, "y": 8 },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 8
+      },
       "id": 5,
       "options": {
-        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "sum by (upstream, code) (rate(registry_http_requests_total[5m]))",
           "legendFormat": "{{upstream}} {{code}}",
@@ -263,10 +392,15 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -274,20 +408,47 @@
             "showPoints": "never"
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 9, "x": 15, "y": 8 },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 8
+      },
       "id": 6,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "histogram_quantile(0.50, sum by (le, upstream) (rate(registry_http_request_duration_seconds_bucket[5m])))",
           "legendFormat": "{{upstream}} p50",
@@ -295,7 +456,10 @@
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "histogram_quantile(0.95, sum by (le, upstream) (rate(registry_http_request_duration_seconds_bucket[5m])))",
           "legendFormat": "{{upstream}} p95",
@@ -303,7 +467,10 @@
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum by (le, upstream) (rate(registry_http_request_duration_seconds_bucket[5m])))",
           "legendFormat": "{{upstream}} p99",
@@ -316,39 +483,79 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 102,
       "panels": [],
       "title": "Storage",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bf02tpxiz6m0wf"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 20,
             "lineWidth": 1,
             "showPoints": "never",
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 15 },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
       "id": 7,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bf02tpxiz6m0wf"
+          },
           "editorMode": "code",
           "expr": "sum by (upstream) (rate(registry_storage_blob_upload_total[5m]))",
           "legendFormat": "{{upstream}}",
@@ -361,15 +568,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
       "id": 103,
       "panels": [],
       "title": "Logs",
       "type": "row"
     },
     {
-      "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 23 },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
       "id": 8,
       "options": {
         "dedupStrategy": "none",
@@ -383,7 +603,10 @@
       },
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "loki" },
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
           "editorMode": "code",
           "expr": "{host=\"registry-cache-01\"} | json | line_format \"{{.container}} {{.level}} {{.message}}\"",
           "queryType": "range",
@@ -396,9 +619,18 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["registry", "docker", "cache"],
-  "templating": { "list": [] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "registry",
+    "docker",
+    "cache"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Registry Cache",

--- a/playbooks/individual/infrastructure/registry_cache.yaml
+++ b/playbooks/individual/infrastructure/registry_cache.yaml
@@ -178,6 +178,72 @@
         state: started
         daemon_reload: yes
 
+    # The registry exposes no on-disk cache-size metric, so publish one via
+    # node-exporter's textfile collector: du each per-upstream data dir.
+    - name: Ensure node-exporter textfile dir exists
+      ansible.builtin.file:
+        path: /data01/services/node-exporter/text_files
+        state: directory
+        mode: '0777'
+
+    - name: Install registry cache-size metric script
+      ansible.builtin.copy:
+        dest: /usr/local/sbin/registry-cache-size-metric
+        mode: '0755'
+        content: |
+          #!/bin/sh
+          set -eu
+          DATA={{ home }}/data
+          OUT=/data01/services/node-exporter/text_files/registry_cache_size.prom
+          TMP=$(mktemp "$OUT.XXXXXX")
+          trap 'rm -f "$TMP"' EXIT
+          printf '# HELP registry_cache_size_bytes On-disk size of the registry pull-through cache per upstream.\n' > "$TMP"
+          printf '# TYPE registry_cache_size_bytes gauge\n' >> "$TMP"
+          for d in docker-hub ghcr gitlab nvcr; do
+            [ -d "$DATA/$d" ] || continue
+            bytes=$(du -sb "$DATA/$d" | cut -f1)
+            printf 'registry_cache_size_bytes{upstream="%s"} %s\n' "$d" "$bytes" >> "$TMP"
+          done
+          chmod 0644 "$TMP"
+          mv "$TMP" "$OUT"
+          trap - EXIT
+
+    - name: Publish cache size metric now (don't wait for the timer)
+      ansible.builtin.command: /usr/local/sbin/registry-cache-size-metric
+      changed_when: false
+
+    - name: Install registry cache-size metric service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/registry-cache-size-metric.service
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=Publish registry cache size to node-exporter textfile collector
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/registry-cache-size-metric
+
+    - name: Install registry cache-size metric timer
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/registry-cache-size-metric.timer
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=Refresh registry cache size metric every 10 minutes
+          [Timer]
+          OnBootSec=3min
+          OnUnitActiveSec=10min
+          Unit=registry-cache-size-metric.service
+          [Install]
+          WantedBy=timers.target
+
+    - name: Enable registry cache-size metric timer
+      ansible.builtin.systemd:
+        name: registry-cache-size-metric.timer
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
   handlers:
     - name: Reload systemd daemon
       ansible.builtin.systemd:


### PR DESCRIPTION
The Registry Cache dashboard queried `registry_proxy_hits/misses_total`, which this registry build never emits — so Pulls/hit-rate panels were empty and there was no cache-size panel at all.

- **Pulls served**: rewrite to `registry_http_requests_total` (manifest GET 2xx) = image pulls per upstream.
- Repurpose the two dead proxy panels → **Total cache size** + **Cache size by upstream**.
- Publish `registry_cache_size_bytes` per upstream via a `du` script + 10m systemd timer into node-exporter's textfile collector (the registry exposes no on-disk size metric).