### PR TITLE
fix(base): mask deprecated/absent systemd units

### DIFF
--- a/inventories/production/hosts.ini
+++ b/inventories/production/hosts.ini
@@ -3,21 +3,21 @@ github_user_id = bluefishforsale
 
 [proxmox]
 node005 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.105 bare_metal_host="node005"
-node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006"
+node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006" masked_units=["nvidia-gpu-exporter.service"]
 
 [baremetal]
 node005 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.105 bare_metal_host="node005"
 node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006"
 
 [vms]
-ocean ansible_user=terrac ansible_python_interpreter=/usr/bin/python3 ansible_ssh_host=192.168.1.143 bare_metal_host="node006" nvidia_gpu=true
-dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005"
+ocean ansible_user=terrac ansible_python_interpreter=/usr/bin/python3 ansible_ssh_host=192.168.1.143 bare_metal_host="node006" nvidia_gpu=true masked_units=["openipmi.service"]
+dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005" masked_units=["named.service"]
 # gitlab ansible_user=debian ansible_ssh_host=192.168.1.5 bare_metal_host="node005"
 pihole ansible_user=debian ansible_ssh_host=192.168.1.9 bare_metal_host="node005" manage_service_users=false
 gh-runner-01 ansible_user=debian ansible_ssh_host=192.168.1.20 bare_metal_host="node005"
 registry-cache-01 ansible_user=debian ansible_ssh_host=192.168.1.30 bare_metal_host="node005" registry_cache_mirror=false
-dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006"
-agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005"
+dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006" masked_units=["named.service"]
+agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005" masked_units=["openipmi.service"]
 
 [agent_hosts]
 agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005"

--- a/playbooks/01_base_system.yaml
+++ b/playbooks/01_base_system.yaml
@@ -32,3 +32,6 @@
 
 - name: Configure RAM Disk (if applicable)
   ansible.builtin.import_playbook: individual/base/ramdisk.yaml
+
+- name: Mask deprecated/absent systemd units
+  ansible.builtin.import_playbook: individual/base/mask_deprecated_units.yaml

--- a/playbooks/individual/base/mask_deprecated_units.yaml
+++ b/playbooks/individual/base/mask_deprecated_units.yaml
@@ -1,0 +1,25 @@
+---
+# Mask systemd units that are deprecated or can never succeed on a given host,
+# so they stop firing SystemdUnitFailed. Per-host list via the `masked_units`
+# inventory var (default empty):
+#   - named.service on dns01/dns02  (replaced by the powerdns container)
+#   - openipmi.service on VMs        (no IPMI hardware)
+#   - nvidia-gpu-exporter on non-GPU hosts
+- name: Mask deprecated/absent systemd units
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Mask units listed in masked_units
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        masked: true
+        enabled: false
+        state: stopped
+      loop: "{{ masked_units | default([]) }}"
+
+    - name: Clear failed state so the alert drops
+      ansible.builtin.command: "systemctl reset-failed {{ item }}"
+      loop: "{{ masked_units | default([]) }}"
+      changed_when: false
+      failed_when: false


### PR DESCRIPTION
Clears persistent SystemdUnitFailed noise for units that can never succeed on their host:
- `named.service` on dns01/dns02 — replaced by the powerdns container
- `openipmi.service` on ocean/agentbox — VMs, no IPMI
- `nvidia-gpu-exporter.service` on node006 — GPU is passed through to ocean

Per-host `masked_units` inventory var + a base-system play that masks and resets-failed each. Verified the var resolves via `ansible-inventory` for all 5 hosts.