### PR TITLE
fix(exporters): gate GPU exporter on inventory flag; start ocean exporters

### DIFF
--- a/playbooks/individual/infrastructure/node_exporter.yaml
+++ b/playbooks/individual/infrastructure/node_exporter.yaml
@@ -140,7 +140,7 @@
   - name: Show GPU detection result
     ansible.builtin.debug:
       msg: "NVIDIA GPU detected: {{ gpu_check.stdout_lines }}"
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
 
   - name: Create NVIDIA GPU exporter Docker Compose directory
     ansible.builtin.file:
@@ -149,7 +149,7 @@
       owner: "{{ uid }}"
       group: "{{ gid }}"
       mode: '0755'
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
 
   - name: Create NVIDIA GPU exporter docker-compose.yml
     ansible.builtin.template:
@@ -158,7 +158,7 @@
       owner: "{{ uid }}"
       group: "{{ gid }}"
       mode: '0644'
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
     register: gpu_docker_compose_config
 
   - name: Create NVIDIA GPU exporter environment file
@@ -168,7 +168,7 @@
       owner: "{{ uid }}"
       group: "{{ gid }}"
       mode: '0600'
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
     register: gpu_env_config
 
   - name: Create NVIDIA GPU exporter README documentation
@@ -178,7 +178,7 @@
       owner: "{{ uid }}"
       group: "{{ gid }}"
       mode: '0644'
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
 
   - name: Create process-exporter systemd service (non-compose)
     ansible.builtin.template:
@@ -315,7 +315,7 @@
       src: "{{ nvidia_gpu_exporter_files }}/nvidia-gpu-exporter.service.j2"
       dest: "/etc/systemd/system/nvidia-gpu-exporter.service"
       mode: '0644'
-    when: gpu_check.rc == 0 and docker_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool) and docker_check.rc == 0
     notify:
     - Reload systemd daemon
     - Restart services
@@ -324,7 +324,7 @@
   - name: Show GPU configuration status
     ansible.builtin.debug:
       msg: "GPU configuration files have been updated - containers will be recreated"
-    when: gpu_check.rc == 0 and docker_check.rc == 0 and (gpu_docker_compose_config.changed or gpu_env_config.changed)
+    when: (nvidia_gpu | default(false) | bool) and docker_check.rc == 0 and (gpu_docker_compose_config.changed or gpu_env_config.changed)
 
   - name: Force GPU container recreation when configs change
     ansible.builtin.shell: |
@@ -333,7 +333,7 @@
       docker compose down --timeout 30
       docker compose up -d --force-recreate
       echo "GPU container recreation completed"
-    when: gpu_check.rc == 0 and docker_check.rc == 0 and (gpu_docker_compose_config.changed or gpu_env_config.changed)
+    when: (nvidia_gpu | default(false) | bool) and docker_check.rc == 0 and (gpu_docker_compose_config.changed or gpu_env_config.changed)
     
   - name: Start and enable process-exporter (non-compose service)
     ansible.builtin.systemd:
@@ -371,7 +371,7 @@
       name: nvidia-gpu-exporter.service
       state: started
       enabled: true
-    when: gpu_check.rc == 0 and docker_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool) and docker_check.rc == 0
 
   - name: Start and enable SMART exporter Docker Compose service
     ansible.builtin.systemd:
@@ -405,7 +405,7 @@
     ansible.builtin.systemd:
       name: nvidia-gpu-exporter.service
       state: restarted
-    when: gpu_check.rc == 0
+    when: (nvidia_gpu | default(false) | bool)
 
   - name: Restart smart exporter service
     ansible.builtin.systemd:

--- a/playbooks/individual/ocean/media/prowlarr.yaml
+++ b/playbooks/individual/ocean/media/prowlarr.yaml
@@ -53,6 +53,13 @@
     - Reload exporter systemd daemon
     - Restart exporter service
 
+  - name: Enable and start prowlarr-exporter service
+    ansible.builtin.systemd:
+      name: prowlarr-exporter.service
+      enabled: yes
+      state: started
+      daemon_reload: yes
+
   handlers:
   - name: Reload prowlarr systemd daemon
     ansible.builtin.systemd:

--- a/playbooks/individual/ocean/media/radarr.yaml
+++ b/playbooks/individual/ocean/media/radarr.yaml
@@ -62,6 +62,13 @@
         - Reload exporter systemd daemon
         - Restart exporter service
 
+    - name: Enable and start radarr-exporter service
+      ansible.builtin.systemd:
+        name: radarr-exporter.service
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
   handlers:
     - name: Reload radarr systemd daemon
       ansible.builtin.systemd:


### PR DESCRIPTION
Two fixes from the alert sweep:
- **node_exporter.yaml** gated the NVIDIA GPU exporter on `lspci | grep nvidia`, which matches on **node006** (the card is physically present but bound to vfio for passthrough to ocean). The exporter fails to start there and aborts the whole play. Gate on the inventory `nvidia_gpu` flag so it only runs on ocean.
- **prowlarr/radarr** exporters only had a restart-on-change handler, so a stopped service stayed stopped. Add an explicit enable+start task.

Note: cadvisor/node_exporter/fail2ban-exporter ServiceDown on agentbox/pihole are NOT fixed here — those hosts have no Docker, so it's a prometheus scrape-config mismatch (separate).