### PR TITLE
fix(base): split masked_units ini string into a list

### DIFF
--- a/inventories/production/hosts.ini
+++ b/inventories/production/hosts.ini
@@ -3,21 +3,21 @@ github_user_id = bluefishforsale
 
 [proxmox]
 node005 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.105 bare_metal_host="node005"
-node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006" masked_units=["nvidia-gpu-exporter.service"]
+node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006" masked_units=nvidia-gpu-exporter.service
 
 [baremetal]
 node005 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.105 bare_metal_host="node005"
 node006 ansible_user=root nvidia_gpu=false dell_perc=true x520_da2_nic=false apcupsd=true ansible_ssh_host=192.168.1.106 bare_metal_host="node006"
 
 [vms]
-ocean ansible_user=terrac ansible_python_interpreter=/usr/bin/python3 ansible_ssh_host=192.168.1.143 bare_metal_host="node006" nvidia_gpu=true masked_units=["openipmi.service"]
-dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005" masked_units=["named.service"]
+ocean ansible_user=terrac ansible_python_interpreter=/usr/bin/python3 ansible_ssh_host=192.168.1.143 bare_metal_host="node006" nvidia_gpu=true masked_units=openipmi.service
+dns01 ansible_user=debian ansible_ssh_host=192.168.1.2 bare_metal_host="node005" masked_units=named.service
 # gitlab ansible_user=debian ansible_ssh_host=192.168.1.5 bare_metal_host="node005"
 pihole ansible_user=debian ansible_ssh_host=192.168.1.9 bare_metal_host="node005" manage_service_users=false
 gh-runner-01 ansible_user=debian ansible_ssh_host=192.168.1.20 bare_metal_host="node005"
 registry-cache-01 ansible_user=debian ansible_ssh_host=192.168.1.30 bare_metal_host="node005" registry_cache_mirror=false
-dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006" masked_units=["named.service"]
-agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005" masked_units=["openipmi.service"]
+dns02 ansible_user=debian ansible_ssh_host=192.168.1.3 bare_metal_host="node006" masked_units=named.service
+agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005" masked_units=openipmi.service
 
 [agent_hosts]
 agentbox ansible_user=debian ansible_ssh_host=192.168.1.31 bare_metal_host="node005"

--- a/playbooks/individual/base/mask_deprecated_units.yaml
+++ b/playbooks/individual/base/mask_deprecated_units.yaml
@@ -1,34 +1,39 @@
 ---
 # Mask systemd units that are deprecated or can never succeed on a given host,
 # so they stop firing SystemdUnitFailed. Per-host list via the `masked_units`
-# inventory var (default empty):
+# inventory var (comma-separated string, default empty):
 #   - named.service on dns01/dns02  (replaced by the powerdns container)
 #   - openipmi.service on VMs        (no IPMI hardware)
 #   - nvidia-gpu-exporter on non-GPU hosts
+# ini host vars arrive as strings, so split on comma rather than expecting a list.
 - name: Mask deprecated/absent systemd units
   hosts: all
   become: true
   gather_facts: false
   tasks:
+    - name: Compute unit list from the masked_units string
+      ansible.builtin.set_fact:
+        _masked_units: "{{ (masked_units | default('') | string).split(',') | map('trim') | select | list }}"
+
     # Stop/disable first (tolerant): can't stop a unit in the same call that
-    # masks it, and the unit may already be inactive or absent.
+    # masks it, and the unit may already be inactive, masked, or absent.
     - name: Stop and disable units before masking
       ansible.builtin.systemd:
         name: "{{ item }}"
         state: stopped
         enabled: false
-      loop: "{{ masked_units | default([]) }}"
+      loop: "{{ _masked_units }}"
       failed_when: false
 
-    - name: Mask units listed in masked_units
+    - name: Mask units
       ansible.builtin.systemd:
         name: "{{ item }}"
         masked: true
-      loop: "{{ masked_units | default([]) }}"
+      loop: "{{ _masked_units }}"
       failed_when: false
 
     - name: Clear failed state so the alert drops
       ansible.builtin.command: "systemctl reset-failed {{ item }}"
-      loop: "{{ masked_units | default([]) }}"
+      loop: "{{ _masked_units }}"
       changed_when: false
       failed_when: false


### PR DESCRIPTION
ini host vars parse as strings, so `masked_units=["x"]` became the literal string and `loop` errored ("must resolve to a list, not str") — an error type `failed_when` can't catch, which is why every masking deploy failed. Store plain comma-strings in the inventory and split into `_masked_units` in the play. Verified the split resolves to a list and empty → [].