### PR TITLE
fix(prometheus): trim no-Docker hosts from container-exporter scrapes

### DIFF
--- a/files/ocean-prometheus/prometheus.yml.j2
+++ b/files/ocean-prometheus/prometheus.yml.j2
@@ -48,7 +48,8 @@ scrape_configs:
     scrape_timeout: 30s
     relabel_configs: *dropPortNumber
     static_configs:
-{% for host in groups['all'] %}
+{# pihole runs no node_exporter (no Docker, no binary) #}
+{% for host in groups['all'] if host != 'pihole' %}
     - targets: ['{{ host }}.home:9100']
 {% endfor %}
 
@@ -60,14 +61,16 @@ scrape_configs:
   - job_name: 'cadvisor'
     relabel_configs: *dropPortNumber
     static_configs:
-{% for host in groups['all'] %}
+{# agentbox and pihole run no Docker, so no cadvisor container #}
+{% for host in groups['all'] if host not in ['agentbox', 'pihole'] %}
     - targets: ['{{ host }}.home:8912']
 {% endfor %}
 
   - job_name: 'fail2ban-exporter'
     relabel_configs: *dropPortNumber
     static_configs:
-{% for host in groups['all'] %}
+{# agentbox and pihole run no Docker, so no fail2ban-exporter container #}
+{% for host in groups['all'] if host not in ['agentbox', 'pihole'] %}
     - targets: ['{{ host }}.home:9191']
 {% endfor %}
 


### PR DESCRIPTION
agentbox and pihole run no Docker, so cadvisor/fail2ban-exporter can never come up there, and pihole runs no node_exporter — 5 permanent ServiceDown alerts. Exclude those hosts from the cadvisor/fail2ban-exporter jobs and pihole from node_exporter. agentbox keeps node_exporter (binary one is up).