### PR TITLE
feat(pihole): binary node_exporter

### DIFF
--- a/files/ocean-prometheus/prometheus.yml.j2
+++ b/files/ocean-prometheus/prometheus.yml.j2
@@ -48,8 +48,7 @@ scrape_configs:
     scrape_timeout: 30s
     relabel_configs: *dropPortNumber
     static_configs:
-{# pihole runs no node_exporter (no Docker, no binary) #}
-{% for host in groups['all'] if host != 'pihole' %}
+{% for host in groups['all'] %}
     - targets: ['{{ host }}.home:9100']
 {% endfor %}
 

--- a/playbooks/individual/core/services/pi_hole.yaml
+++ b/playbooks/individual/core/services/pi_hole.yaml
@@ -254,9 +254,35 @@
           - "✓ Local DNS working - ocean.home resolves to: {{ local_dns_result.stdout }}"
           - "✓ External DNS working - google.com resolves to: {{ external_dns_result.stdout_lines[0] }}"
 
+    # Host metrics: native node_exporter (pihole runs no docker), same as agentbox.
+    - name: Install Prometheus node exporter
+      ansible.builtin.apt:
+        name: prometheus-node-exporter
+        state: present
+
+    - name: Enable systemd + processes collectors
+      ansible.builtin.copy:
+        dest: /etc/default/prometheus-node-exporter
+        content: |
+          # Managed by ansible (pi_hole.yaml)
+          ARGS="--collector.systemd --collector.processes"
+        mode: '0644'
+      notify: Restart node exporter
+
+    - name: Enable and start node exporter
+      ansible.builtin.systemd:
+        name: prometheus-node-exporter
+        enabled: true
+        state: started
+
   handlers:
     - name: Restart pihole-FTL
       ansible.builtin.service:
         name: pihole-FTL
+        state: restarted
+
+    - name: Restart node exporter
+      ansible.builtin.systemd:
+        name: prometheus-node-exporter
         state: restarted
 


### PR DESCRIPTION
Keep pihole monitored: install the Debian prometheus-node-exporter (systemd+processes collectors, :9100) like agentbox, and revert the node_exporter scrape trim so pihole is scraped again. cadvisor/fail2ban-exporter stay trimmed (no Docker).