### PR TITLE
fix(ethtool): exclude docker/virtual bridges from NIC tuning

### DIFF
--- a/playbooks/individual/core/network/ethtool.yaml
+++ b/playbooks/individual/core/network/ethtool.yaml
@@ -12,7 +12,7 @@
 
     - name: Gather list of all network interfaces excluding unwanted types
       ansible.builtin.shell: |
-        ip -o link show | awk -F': ' '{print $2}' | grep -Ev '^(lo|vmbr|tap|veth|bond)'
+        ip -o link show | awk -F': ' '{print $2}' | grep -Ev '^(lo|vmbr|tap|veth|bond|docker|br-|dummy|virbr)'
       register: network_interfaces
       changed_when: false
 


### PR DESCRIPTION
The interface filter only skipped lo/vmbr/tap/veth/bond, so on docker hosts it also selected docker0 and br-* bridges and tried to set speed/duplex/channels on them → "Operation not supported" (exit 75). node005 tolerated it via `ExecStart=-`; the stale unit on ocean (no dash) failed outright. Exclude `docker|br-|dummy|virbr` so only physical NICs are configured. (Ocean unit was orphaned — not in [proxmox] — and removed directly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)