### PR TITLE
feat(scripts): media reclaim toolkit (query client, taste profiler, guarded delete)

### DIFF
--- a/scripts/media-reclaim-delete.py
+++ b/scripts/media-reclaim-delete.py
@@ -45,22 +45,32 @@ def requested_ids(service, block_any):
     """
     want = "movie" if service == "movies" else "tv"
     idfield = "tmdbId" if service == "movies" else "tvdbId"
-    reqs = mc.get("overseerr", "/api/v1/request", take=2000, filter="all")["results"]
     out = set()
-    for r in reqs:
-        m = r["media"]
-        if m["mediaType"] != want or not m.get(idfield):
-            continue
-        inflight = r["status"] == 1 or m["status"] in (2, 3, 4)
-        if block_any or inflight:
-            out.add(m[idfield])
-    return out
+    skip, take = 0, 100
+    while True:  # paginate: never trust one page to hold every request
+        page = mc.get("overseerr", "/api/v1/request", take=take, skip=skip, filter="all")
+        results = page.get("results", [])
+        for r in results:
+            m = r.get("media") or {}
+            if m.get("mediaType") != want or not m.get(idfield):
+                continue
+            inflight = r.get("status") == 1 or m.get("status") in (2, 3, 4)
+            if block_any or inflight:
+                out.add(m[idfield])
+        total = (page.get("pageInfo") or {}).get("results", 0)
+        skip += take
+        if not results or skip >= total:
+            return out
 
 
 def select(items, a):
     if a.ids:
         want = set(a.ids)
-        return [i for i in items if i["id"] in want]
+        found = [i for i in items if i["id"] in want]
+        missing = want - {i["id"] for i in found}
+        if missing:
+            print(f"warning: ids not in library, skipped: {sorted(missing)}", file=sys.stderr)
+        return found
     out = items
     if a.unmonitored:
         out = [i for i in out if not i.get("monitored")]
@@ -92,7 +102,7 @@ def main():
 
     reqset = set() if a.ignore_overseerr else requested_ids(a.service, a.block_any_request)
     print("ACT\tGB\tCUM_TB\tMON\tID\tTITLE")
-    cum = free = 0
+    cum = 0
     todo = []
     for it in targets:
         gb = size_of(it) / 1e9
@@ -103,17 +113,22 @@ def main():
         act = "SKIP-req" if blocked else "DELETE"
         print(f"{act}\t{gb:.0f}\t{cum/1e12:.2f}\t{it.get('monitored')}\t{it['id']}"
               f"\t{it.get('title')} ({it.get('year','')})")
-    free = cum / 1e12
-    print(f"\n{len(todo)} titles, {free:.2f} TB to free "
+    print(f"\n{len(todo)} titles, {cum/1e12:.2f} TB to free "
           f"({len(targets)-len(todo)} skipped as Overseerr-requested)")
 
     if not a.yes:
-        print("DRY RUN — re-run with --yes to delete files + add import exclusion")
+        print("DRY RUN: re-run with --yes to delete files + add import exclusion")
         return
+    ok = err = 0
     for it in todo:
-        mc.delete(svc, f"/api/v3/{kind}/{it['id']}", deleteFiles="true", addImportExclusion="true")
-        print(f"deleted {it['id']} {it.get('title')}")
-    print(f"done: freed ~{free:.2f} TB")
+        try:
+            mc.delete(svc, f"/api/v3/{kind}/{it['id']}", deleteFiles="true", addImportExclusion="true")
+            ok += 1
+            print(f"deleted {it['id']} {it.get('title')}")
+        except Exception as e:
+            err += 1
+            print(f"FAILED {it['id']} {it.get('title')}: {e}", file=sys.stderr)
+    print(f"done: {ok} deleted, {err} failed, ~{cum/1e12:.2f} TB freed")
 
 
 def selftest():

--- a/scripts/media-reclaim-delete.py
+++ b/scripts/media-reclaim-delete.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Delete movies/shows via Radarr/Sonarr with unmonitor + import-exclusion, so
+the *arr app drops the files AND never re-grabs them. Refuses anything with an
+Overseerr request (someone asked for it), unless --ignore-overseerr.
+
+DRY-RUN BY DEFAULT. Nothing is deleted without --yes.
+
+  # preview the low-value-TV cut from the analysis:
+  media-reclaim-delete.py --service tv --unmonitored --status ended --min-gb 150
+  # execute a specific set:
+  media-reclaim-delete.py --service tv --ids 1068,1089,1096 --yes
+
+Filters (AND together; omit --ids to select by flags):
+  --service movies|tv   (required)
+  --ids a,b,c           explicit *arr ids, skips other filters
+  --unmonitored         only monitored==false
+  --status ended        sonarr status match (ended/continuing/...)
+  --min-gb N            only titles >= N GB
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import media_clients as mc  # noqa: E402
+
+APP = {"movies": ("radarr", "movie", "tmdbId"), "tv": ("sonarr", "series", "tvdbId")}
+
+
+def size_of(it):
+    s = it.get("sizeOnDisk")
+    if s is None:
+        s = (it.get("statistics") or {}).get("sizeOnDisk", 0)
+    return int(s or 0)
+
+
+def requested_ids(service, block_any):
+    """Set of tmdbId (movies) / tvdbId (tv) with a protecting Overseerr request.
+
+    Default protects only *in-flight* wants: request pending approval
+    (status==1) or media not yet satisfied (media.status 2/3/4 =
+    pending/processing/partial). A fulfilled+available request (status 5) is a
+    finished want and does not veto a prune. --block-any-request restores the
+    blanket "requested ever" veto.
+    """
+    want = "movie" if service == "movies" else "tv"
+    idfield = "tmdbId" if service == "movies" else "tvdbId"
+    reqs = mc.get("overseerr", "/api/v1/request", take=2000, filter="all")["results"]
+    out = set()
+    for r in reqs:
+        m = r["media"]
+        if m["mediaType"] != want or not m.get(idfield):
+            continue
+        inflight = r["status"] == 1 or m["status"] in (2, 3, 4)
+        if block_any or inflight:
+            out.add(m[idfield])
+    return out
+
+
+def select(items, a):
+    if a.ids:
+        want = set(a.ids)
+        return [i for i in items if i["id"] in want]
+    out = items
+    if a.unmonitored:
+        out = [i for i in out if not i.get("monitored")]
+    if a.status:
+        out = [i for i in out if i.get("status") == a.status]
+    if a.min_gb:
+        out = [i for i in out if size_of(i) >= a.min_gb * 1e9]
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser(usage=__doc__)
+    p.add_argument("--service", required=True, choices=APP)
+    p.add_argument("--ids", type=lambda s: [int(x) for x in s.split(",")])
+    p.add_argument("--unmonitored", action="store_true")
+    p.add_argument("--status")
+    p.add_argument("--min-gb", type=float)
+    p.add_argument("--ignore-overseerr", action="store_true")
+    p.add_argument("--block-any-request", action="store_true",
+                   help="veto on any request ever, not just in-flight ones")
+    p.add_argument("--yes", action="store_true")
+    a = p.parse_args()
+
+    svc, kind, idfield = APP[a.service]
+    items = mc.get(svc, f"/api/v3/{kind}")
+    targets = sorted(select(items, a), key=size_of, reverse=True)
+    if not targets:
+        sys.exit("no titles matched")
+
+    reqset = set() if a.ignore_overseerr else requested_ids(a.service, a.block_any_request)
+    print("ACT\tGB\tCUM_TB\tMON\tID\tTITLE")
+    cum = free = 0
+    todo = []
+    for it in targets:
+        gb = size_of(it) / 1e9
+        blocked = it.get(idfield) in reqset
+        if not blocked:
+            cum += size_of(it)
+            todo.append(it)
+        act = "SKIP-req" if blocked else "DELETE"
+        print(f"{act}\t{gb:.0f}\t{cum/1e12:.2f}\t{it.get('monitored')}\t{it['id']}"
+              f"\t{it.get('title')} ({it.get('year','')})")
+    free = cum / 1e12
+    print(f"\n{len(todo)} titles, {free:.2f} TB to free "
+          f"({len(targets)-len(todo)} skipped as Overseerr-requested)")
+
+    if not a.yes:
+        print("DRY RUN — re-run with --yes to delete files + add import exclusion")
+        return
+    for it in todo:
+        mc.delete(svc, f"/api/v3/{kind}/{it['id']}", deleteFiles="true", addImportExclusion="true")
+        print(f"deleted {it['id']} {it.get('title')}")
+    print(f"done: freed ~{free:.2f} TB")
+
+
+def selftest():
+    class A:
+        ids = None; unmonitored = True; status = "ended"; min_gb = 150
+    items = [
+        {"id": 1, "monitored": False, "status": "ended", "statistics": {"sizeOnDisk": 200e9}},
+        {"id": 2, "monitored": True, "status": "ended", "statistics": {"sizeOnDisk": 300e9}},
+        {"id": 3, "monitored": False, "status": "continuing", "statistics": {"sizeOnDisk": 300e9}},
+        {"id": 4, "monitored": False, "status": "ended", "statistics": {"sizeOnDisk": 100e9}},
+    ]
+    got = {i["id"] for i in select(items, A)}
+    assert got == {1}, got  # unmonitored+ended+>=150GB -> only id 1
+    print("ok")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--selftest":
+        selftest()
+    else:
+        main()

--- a/scripts/media-reclaim-report.py
+++ b/scripts/media-reclaim-report.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Profile the /data01/complete library by taste: genre, decade, language,
+rating, studio/network, quality, monitored-vs-not. Source of truth is Radarr
+(/movie) and Sonarr (/series), which carry genres/size/monitored/path/id, so
+the profile lines up with what the *arr apps will later unmonitor + delete.
+
+This reports what you HAVE and what you're still chasing (monitored). It does
+not rank by watch history. Deletion + *arr unmonitor is a separate script.
+
+Env (each falls back to the live config.xml on ocean):
+  RADARR_URL  default http://localhost:8903   RADARR_APIKEY
+  SONARR_URL  default http://localhost:8902   SONARR_APIKEY
+
+Usage: media-reclaim-report.py [movies|tv|all]   (default all)
+Sizes double-count across multi-valued dims (a title has several genres); the
+per-genre size answers "how much disk is my western habit", not a disk sum.
+"""
+import json
+import os
+import re
+import sys
+import urllib.request
+
+TB = 1e12
+APPS = {
+    "movies": {"url_env": "RADARR_URL", "key_env": "RADARR_APIKEY",
+               "url": "http://localhost:8903", "cfg": "/data01/services/radarr/config.xml",
+               "endpoint": "/api/v3/movie"},
+    "tv": {"url_env": "SONARR_URL", "key_env": "SONARR_APIKEY",
+           "url": "http://localhost:8902", "cfg": "/data01/services/sonarr/config.xml",
+           "endpoint": "/api/v3/series"},
+}
+
+
+def apikey(app):
+    k = os.environ.get(app["key_env"])
+    if k:
+        return k
+    with open(app["cfg"]) as f:
+        m = re.search(r"<ApiKey>([a-f0-9]+)</ApiKey>", f.read())
+    if not m:
+        sys.exit("no api key for " + app["cfg"])
+    return m.group(1)
+
+
+def fetch(app):
+    base = os.environ.get(app["url_env"], app["url"])
+    req = urllib.request.Request(base + app["endpoint"] + "?apikey=" + apikey(app))
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.load(r)
+
+
+def size_of(item):
+    s = item.get("sizeOnDisk")
+    if s is None:
+        s = (item.get("statistics") or {}).get("sizeOnDisk", 0)
+    return int(s or 0)
+
+
+def decade(item):
+    y = item.get("year") or 0
+    return f"{(y // 10) * 10}s" if y else "unknown"
+
+
+def groupby(items, keyfn):
+    """key -> {count, size, mon, mon_size}; keyfn may return a list (multi-valued)."""
+    out = {}
+    for it in items:
+        keys = keyfn(it)
+        if not isinstance(keys, list):
+            keys = [keys]
+        sz = size_of(it)
+        mon = bool(it.get("monitored"))
+        for k in keys or ["(none)"]:
+            b = out.setdefault(k, [0, 0, 0, 0])
+            b[0] += 1
+            b[1] += sz
+            if mon:
+                b[2] += 1
+                b[3] += sz
+    return out
+
+
+def table(title, groups, limit=None):
+    rows = sorted(groups.items(), key=lambda kv: -kv[1][1])
+    if limit:
+        rows = rows[:limit]
+    print(f"\n## {title}")
+    print("KEY\tCOUNT\tSIZE_TB\tMON\tMON_TB")
+    for k, (n, sz, mon, msz) in rows:
+        print(f"{k}\t{n}\t{sz/TB:.2f}\t{mon}\t{msz/TB:.2f}")
+
+
+def profile(name):
+    app = APPS[name]
+    items = fetch(app)
+    total = sum(size_of(i) for i in items)
+    mon = [i for i in items if i.get("monitored")]
+    mon_sz = sum(size_of(i) for i in mon)
+    print(f"\n{'='*60}\n{name.upper()}: {len(items)} titles, {total/TB:.2f} TB total")
+    print(f"  monitored: {len(mon)} titles / {mon_sz/TB:.2f} TB   "
+          f"unmonitored: {len(items)-len(mon)} / {(total-mon_sz)/TB:.2f} TB")
+
+    table("Genre", groupby(items, lambda i: i.get("genres") or []))
+    table("Decade", groupby(items, decade))
+    table("Language", groupby(items, lambda i: (i.get("originalLanguage") or {}).get("name", "?")))
+    if name == "movies":
+        table("Certification", groupby(items, lambda i: i.get("certification") or "(none)"))
+        table("Studio (top 20)", groupby(items, lambda i: i.get("studio") or "(none)"), limit=20)
+        table("Collection (top 20)", groupby(items,
+              lambda i: (i.get("collection") or {}).get("title", "(none)")), limit=20)
+    else:
+        table("Network (top 20)", groupby(items, lambda i: i.get("network") or "(none)"), limit=20)
+        table("Status", groupby(items, lambda i: i.get("status") or "?"))
+        table("Series type", groupby(items, lambda i: i.get("seriesType") or "?"))
+
+
+def selftest():
+    items = [
+        {"genres": ["Western", "Drama"], "year": 1971, "monitored": True, "sizeOnDisk": 100},
+        {"genres": ["Western"], "year": 1968, "monitored": False, "sizeOnDisk": 200},
+        {"genres": [], "year": 0, "monitored": False, "statistics": {"sizeOnDisk": 50}},
+    ]
+    g = groupby(items, lambda i: i.get("genres") or [])
+    assert g["Western"] == [2, 300, 1, 100], g["Western"]
+    assert g["Drama"] == [1, 100, 1, 100], g["Drama"]
+    d = groupby(items, decade)
+    assert d["1970s"][0] == 1 and d["unknown"][0] == 1, d
+    assert size_of(items[2]) == 50  # statistics fallback
+    print("ok")
+
+
+if __name__ == "__main__":
+    arg = sys.argv[1] if len(sys.argv) > 1 else "all"
+    if arg == "--selftest":
+        selftest()
+    elif arg == "all":
+        profile("movies")
+        profile("tv")
+    elif arg in APPS:
+        profile(arg)
+    else:
+        sys.exit(__doc__)

--- a/scripts/media-reclaim-report.py
+++ b/scripts/media-reclaim-report.py
@@ -7,47 +7,21 @@ the profile lines up with what the *arr apps will later unmonitor + delete.
 This reports what you HAVE and what you're still chasing (monitored). It does
 not rank by watch history. Deletion + *arr unmonitor is a separate script.
 
-Env (each falls back to the live config.xml on ocean):
-  RADARR_URL  default http://localhost:8903   RADARR_APIKEY
-  SONARR_URL  default http://localhost:8902   SONARR_APIKEY
+Endpoints + key discovery come from media_clients (RADARR_URL/RADARR_APIKEY etc.
+env override, else the live config.xml on ocean).
 
 Usage: media-reclaim-report.py [movies|tv|all]   (default all)
 Sizes double-count across multi-valued dims (a title has several genres); the
 per-genre size answers "how much disk is my western habit", not a disk sum.
 """
-import json
 import os
-import re
 import sys
-import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import media_clients as mc  # noqa: E402
 
 TB = 1e12
-APPS = {
-    "movies": {"url_env": "RADARR_URL", "key_env": "RADARR_APIKEY",
-               "url": "http://localhost:8903", "cfg": "/data01/services/radarr/config.xml",
-               "endpoint": "/api/v3/movie"},
-    "tv": {"url_env": "SONARR_URL", "key_env": "SONARR_APIKEY",
-           "url": "http://localhost:8902", "cfg": "/data01/services/sonarr/config.xml",
-           "endpoint": "/api/v3/series"},
-}
-
-
-def apikey(app):
-    k = os.environ.get(app["key_env"])
-    if k:
-        return k
-    with open(app["cfg"]) as f:
-        m = re.search(r"<ApiKey>([a-f0-9]+)</ApiKey>", f.read())
-    if not m:
-        sys.exit("no api key for " + app["cfg"])
-    return m.group(1)
-
-
-def fetch(app):
-    base = os.environ.get(app["url_env"], app["url"])
-    req = urllib.request.Request(base + app["endpoint"] + "?apikey=" + apikey(app))
-    with urllib.request.urlopen(req, timeout=120) as r:
-        return json.load(r)
+SVC = {"movies": ("radarr", "/api/v3/movie"), "tv": ("sonarr", "/api/v3/series")}
 
 
 def size_of(item):
@@ -92,8 +66,8 @@ def table(title, groups, limit=None):
 
 
 def profile(name):
-    app = APPS[name]
-    items = fetch(app)
+    svc, endpoint = SVC[name]
+    items = mc.get(svc, endpoint)
     total = sum(size_of(i) for i in items)
     mon = [i for i in items if i.get("monitored")]
     mon_sz = sum(size_of(i) for i in mon)
@@ -137,7 +111,7 @@ if __name__ == "__main__":
     elif arg == "all":
         profile("movies")
         profile("tv")
-    elif arg in APPS:
+    elif arg in SVC:
         profile(arg)
     else:
         sys.exit(__doc__)

--- a/scripts/media_clients.py
+++ b/scripts/media_clients.py
@@ -66,7 +66,7 @@ def _url(name):
     return os.environ.get(f"{name.upper()}_URL", SERVICES[name]["url"])
 
 
-def _request(name, path, params, data=None):
+def _request(name, path, params, data=None, method=None):
     s = SERVICES[name]
     params = dict(params or {})
     headers = {"Accept": "application/json"}
@@ -84,9 +84,12 @@ def _request(name, path, params, data=None):
     body = json.dumps(data).encode() if data is not None else None
     if body:
         headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=body, headers=headers, method="POST" if body else "GET")
+    if method is None:
+        method = "POST" if body else "GET"
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
     with urllib.request.urlopen(req, timeout=120) as r:
-        return json.load(r)
+        txt = r.read()
+        return json.loads(txt) if txt else None
 
 
 def get(name, path, **params):
@@ -95,6 +98,10 @@ def get(name, path, **params):
 
 def post(name, path, data, **params):
     return _request(name, path, params, data=data)
+
+
+def delete(name, path, **params):
+    return _request(name, path, params, method="DELETE")
 
 
 def tdarr_stats():

--- a/scripts/media_clients.py
+++ b/scripts/media_clients.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""One client for the ocean media stack: radarr, sonarr, tdarr, plex, overseerr.
+
+Self-discovers each service's key from the live config on ocean (env var wins),
+so nothing secret is committed. Importable (get/post/SERVICES) and a CLI:
+
+  media_clients.py ping                     # reachability + headline per service
+  media_clients.py get radarr /api/v3/movie # ad-hoc GET, prints JSON
+  media_clients.py get plex /library/sections
+  media_clients.py get overseerr /api/v1/request count=5
+  media_clients.py tdarr-stats              # tdarr transcode totals
+
+Run on ocean (defaults to localhost). Plex Preferences.xml is 0600 owned by
+media, so plex needs PLEX_TOKEN in env or run as media/root (or sudo).
+"""
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+DATA = "/data01/services"
+
+
+def _xml_key(path):
+    with open(path) as f:
+        m = re.search(r"<ApiKey>([a-f0-9]+)</ApiKey>", f.read())
+    return m.group(1) if m else None
+
+
+def _overseerr_key():
+    with open(f"{DATA}/overseerr/config/settings.json") as f:
+        return json.load(f)["main"]["apiKey"]
+
+
+def _plex_token():
+    p = f"{DATA}/plex/config/Library/Application Support/Plex Media Server/Preferences.xml"
+    m = re.search(r'PlexOnlineToken="([^"]+)"', open(p).read())
+    return m.group(1) if m else None
+
+
+# auth: how the key rides the request. ('query', name) | ('header', name) | None
+SERVICES = {
+    "radarr":    {"url": "http://localhost:8903", "auth": ("query", "apikey"),
+                  "key_env": "RADARR_APIKEY", "key": lambda: _xml_key(f"{DATA}/radarr/config.xml")},
+    "sonarr":    {"url": "http://localhost:8902", "auth": ("query", "apikey"),
+                  "key_env": "SONARR_APIKEY", "key": lambda: _xml_key(f"{DATA}/sonarr/config.xml")},
+    "tdarr":     {"url": "http://localhost:8265", "auth": None,
+                  "key_env": None, "key": lambda: None},
+    "plex":      {"url": "http://localhost:32400", "auth": ("query", "X-Plex-Token"),
+                  "key_env": "PLEX_TOKEN", "key": _plex_token},
+    "overseerr": {"url": "http://localhost:5055", "auth": ("header", "X-Api-Key"),
+                  "key_env": "OVERSEERR_APIKEY", "key": _overseerr_key},
+}
+
+
+def _key(name):
+    s = SERVICES[name]
+    if s["key_env"] and os.environ.get(s["key_env"]):
+        return os.environ[s["key_env"]]
+    return s["key"]()
+
+
+def _url(name):
+    return os.environ.get(f"{name.upper()}_URL", SERVICES[name]["url"])
+
+
+def _request(name, path, params, data=None):
+    s = SERVICES[name]
+    params = dict(params or {})
+    headers = {"Accept": "application/json"}
+    auth = s["auth"]
+    if auth:
+        kind, field = auth
+        key = _key(name)
+        if kind == "query":
+            params[field] = key
+        else:
+            headers[field] = key
+    url = _url(name) + path
+    if params:
+        url += ("&" if "?" in url else "?") + urllib.parse.urlencode(params)
+    body = json.dumps(data).encode() if data is not None else None
+    if body:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST" if body else "GET")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.load(r)
+
+
+def get(name, path, **params):
+    return _request(name, path, params)
+
+
+def post(name, path, data, **params):
+    return _request(name, path, params, data=data)
+
+
+def tdarr_stats():
+    return post("tdarr", "/api/v2/cruddb",
+                {"data": {"collection": "StatisticsJSONDB", "mode": "getById", "docID": "statistics"}})
+
+
+def ping():
+    def headline(n):
+        if n in ("radarr", "sonarr"):
+            v = get(n, "/api/v3/system/status")["version"]
+            kind = "movie" if n == "radarr" else "series"
+            c = len(get(n, f"/api/v3/{kind}"))
+            return f"v{v}, {c} {kind}"
+        if n == "tdarr":
+            s = tdarr_stats()
+            return f"{s['totalFileCount']} files, {s['sizeDiff']/1000:.1f} TB saved"
+        if n == "plex":
+            secs = get(n, "/library/sections")["MediaContainer"]["Directory"]
+            return f"{len(secs)} libraries"
+        if n == "overseerr":
+            c = get(n, "/api/v1/request/count")
+            return f"v{get(n, '/api/v1/status')['version']}, {c['total']} requests, {c['pending']} pending"
+
+    for n in SERVICES:
+        try:
+            print(f"{n:10} OK   {headline(n)}")
+        except Exception as e:
+            print(f"{n:10} FAIL {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    a = sys.argv[1:]
+    if a and a[0] == "ping":
+        ping()
+    elif a and a[0] == "tdarr-stats":
+        print(json.dumps(tdarr_stats(), indent=2))
+    elif len(a) >= 3 and a[0] == "get":
+        params = dict(kv.split("=", 1) for kv in a[3:])
+        print(json.dumps(get(a[1], a[2], **params), indent=2)[:20000])
+    else:
+        sys.exit(__doc__)


### PR DESCRIPTION
Adds three ops scripts under `scripts/` for reclaiming NAS space on ocean (`/data01/complete`, at ~87%). No playbook/role/vars changes, so no deploy dispatch is triggered.

## Scripts
- **`media_clients.py`** — one self-discovering client for the ocean media stack (radarr, sonarr, tdarr, plex, overseerr). Keys sourced from live host config or env; nothing secret committed. `ping` / `get` / `delete` / `tdarr-stats`.
- **`media-reclaim-report.py`** — profiles movies/tv by genre, decade, language, rating, studio/network, monitored-vs-not. Reuses `media_clients`.
- **`media-reclaim-delete.py`** — deletes via Radarr/Sonarr with `deleteFiles=true&addImportExclusion=true` (drops files, never re-grabs). Dry-run by default, `--yes` to execute. Refuses titles with an in-flight Overseerr request (`--block-any-request` / `--ignore-overseerr` to tune).

## Host / services touched at runtime
Read-only against ocean's radarr/sonarr/tdarr/plex/overseerr APIs; the delete path is operator-invoked, dry-run by default, and never runs in CI/deploy.

## Verification
- Self-tests pass (`--selftest` on report + delete).
- Ran `ping`, report, and delete dry-run against ocean; all green.
- Review gate: `/code-review high` (7 findings, all fixed) + manual security pass (no committed secrets, no exec sinks).