### PR TITLE
fix(alerts): fail2ban journald backend, logrotate dedup, hypervisor mem 95%

### DIFF
--- a/files/ocean-prometheus/alert_rules.yml.j2
+++ b/files/ocean-prometheus/alert_rules.yml.j2
@@ -11,15 +11,28 @@ groups:
       summary: "High CPU usage on {{ "{{ $labels.instance }}" }}"
       description: "CPU usage is above 80% for more than 5 minutes on {{ "{{ $labels.instance }}" }}"
 
-  # High memory usage alert
+  # High memory usage alert. The Proxmox hypervisors (node005/node006) run VMs
+  # that pre-allocate RAM, so they sit near-full by design; they get a higher
+  # 95% bar in the companion rule below. All other hosts alert at 85%.
   - alert: HighMemoryUsage
-    expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 85
+    expr: (node_memory_MemTotal_bytes{instance!~"node00[56].home"} - node_memory_MemAvailable_bytes{instance!~"node00[56].home"}) / node_memory_MemTotal_bytes{instance!~"node00[56].home"} * 100 > 85
     for: 5m
     labels:
       severity: warning
     annotations:
       summary: "High memory usage on {{ "{{ $labels.instance }}" }}"
       description: "Memory usage is above 85% for more than 5 minutes on {{ "{{ $labels.instance }}" }}"
+
+  # Hypervisor memory: node005/node006 run near-full by design, so only alert
+  # them at 95% — real host-memory exhaustion, not normal VM allocation.
+  - alert: HighMemoryUsageHypervisor
+    expr: (node_memory_MemTotal_bytes{instance=~"node00[56].home"} - node_memory_MemAvailable_bytes{instance=~"node00[56].home"}) / node_memory_MemTotal_bytes{instance=~"node00[56].home"} * 100 > 95
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "High memory usage on hypervisor {{ "{{ $labels.instance }}" }}"
+      description: "Memory usage is above 95% for more than 5 minutes on hypervisor {{ "{{ $labels.instance }}" }}"
 
   # High disk usage alert
   - alert: HighDiskUsage

--- a/playbooks/individual/base/fail2ban.yaml
+++ b/playbooks/individual/base/fail2ban.yaml
@@ -38,7 +38,10 @@
           enabled = true
           port = ssh
           filter = sshd
-          logpath = /var/log/auth.log
+          # These hosts log ssh to journald, not /var/log/auth.log (which does
+          # not exist), so read from systemd — otherwise fail2ban fails to start
+          # with "Have not found any log file for sshd jail".
+          backend = systemd
           maxretry = 3
           findtime = 120
           bantime = 86400

--- a/playbooks/individual/base/logging.yaml
+++ b/playbooks/individual/base/logging.yaml
@@ -65,6 +65,11 @@
     - Restart systemd-journald
 
   ########### System log rotation
+  - name: Remove stale logrotate.d/homelab (old filename; duplicates syslog/kern.log with the rsyslog config below and breaks logrotate)
+    ansible.builtin.file:
+      path: /etc/logrotate.d/homelab
+      state: absent
+
   - name: Configure logrotate for system logs
     ansible.builtin.copy:
       dest: /etc/logrotate.d/rsyslog


### PR DESCRIPTION
Resolves open Alertmanager alerts.

**fail2ban** (SystemdUnitFailed on node005/node006) — sshd jail used `logpath = /var/log/auth.log`, which does not exist on these hosts (ssh logs to journald), so fail2ban failed to start ("Have not found any log file for sshd jail"). Switch the jail to `backend = systemd`.

**logrotate** (SystemdUnitFailed on node005) — a stale `/etc/logrotate.d/homelab` (old filename) duplicated `/var/log/syslog` + `kern.log` with the current `rsyslog` config, so logrotate errored nightly ("duplicate log entry"). Remove the stale file.

**HighMemoryUsage** (node005 at 88%) — the Proxmox hypervisors run near-full by design (VMs pre-allocate RAM). Exclude node005/node006 from the 85% rule and add `HighMemoryUsageHypervisor` at **95%** so only real host-memory exhaustion pages.

Deploys scoped to fail2ban + logging + prometheus playbooks. Note: fail2ban/logging target `hosts: all`, so main-apply will report failure on **node006** (SSH-unreachable from the runner) but the fixes apply to all reachable hosts including node005. jellyfin ServiceDown is separate (needs a Jellyfin API key — no admin creds in vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)