### PR TITLE
fix(pmm): migrate plex-meta-manager to Kometa (broken ~8 months)

### DIFF
--- a/files/ocean-plex/meta-manager/config.yml.j2
+++ b/files/ocean-plex/meta-manager/config.yml.j2
@@ -4,30 +4,29 @@ libraries:                                      # This is called out once within
     metadata_path:
     - file: config/Movies.yml                   # This is a local file on the system
     - folder: config/movies/                    # This is a local directory on the system
-    - pmm: seasonal
-    - pmm: basic                                # This is a file within the defaults folder in the Repository
-    - pmm: imdb                                 # This is a file within the defaults folder in the Repository
-    - pmm: franchise
+    - default: seasonal
+    - default: basic                                # This is a file within the defaults folder in the Repository
+    - default: imdb                                 # This is a file within the defaults folder in the Repository
+    - default: franchise
       template_variables:
         collection_order: release
         build_collection: true
         radarr_add_missing: true
-    - pmm: studio
-    - pmm: tautulli
-    - pmm: content_rating_us
-    - pmm: oscars
-    - pmm: cannes
-    - pmm: sundance
-    - pmm: director
+    - default: studio
+    - default: tautulli
+    - default: content_rating_us
+    - default: oscars
+    - default: cannes
+    - default: sundance
+    - default: director
     operations:
       delete_unmanaged_collections: true
     overlay_path:
     - remove_overlays: false                    # Set this to true to remove all overlays
     - file: config/Overlays.yml                 # This is a local file on the system
-    - pmm: ribbon                               # This is a file within the defaults folder in the Repository
+    - default: ribbon                               # This is a file within the defaults folder in the Repository
 playlist_files:
-- file: config/playlists.yml
-- pmm: playlist                                 # This is a file within the defaults folder in the Repository
+- default: playlist                                 # This is a file within the defaults folder in the Repository
 settings:
   cache: true
   cache_expiration: 60

--- a/playbooks/individual/ocean/media/plex.yaml
+++ b/playbooks/individual/ocean/media/plex.yaml
@@ -45,7 +45,7 @@
     exporter_version: latest
     exporter_port: "{{ service_ports.plex_exporter.port }}"
     meta_manager_service: plex-meta-manager
-    meta_manager_image: meisnate12/plex-meta-manager
+    meta_manager_image: kometateam/kometa
     meta_manager_version: latest
     data: /data01
     files: "{{ playbook_dir }}/../../../../files/ocean-plex"


### PR DESCRIPTION
Plex Meta Manager has been **crashing at every 05:00 run since 2025-11-13 (~8 months)** — nothing has updated collections/overlays since. `meta.log` shows `CRITICAL: Extra data: line 1 column 4 (char 3)` with Run Time 0:00:00.

**Root cause:** the container runs the frozen `meisnate12/plex-meta-manager:latest` (v1.21.0). The project was renamed to **Kometa**; v1.21.0 fetches its `pmm:` defaults from a repo that now returns `404: Not Found` (plain text), and PMM calls `.json()` on the `404: Not Found` body → JSONDecodeError (`404` parses, `:` at char 3 is "extra data") → the whole run aborts.

**Fix — migrate to Kometa v2:**
- image `meisnate12/plex-meta-manager` → `kometateam/kometa`
- config `pmm:` default refs → `default:` (renamed in v2)
- drop the missing `config/playlists.yml` file ref (was a File Error); keep `default: playlist`

**Verification plan:** after deploy I will run Kometa manually once and watch it complete without the JSON crash and rebuild collections — in case any specific default file was renamed in v2 (those would surface as per-file errors, not a full crash, and I would patch in follow-up).

Note: only a **Movies** library is configured — no TV. Flag if you want TV collections managed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)