### PR TITLE
fix(plex): make plex.yaml deployable via CI (was aborting on gitignored secrets)

### DIFF
--- a/files/ocean-plex/meta-manager/config.yml.j2
+++ b/files/ocean-plex/meta-manager/config.yml.j2
@@ -87,7 +87,7 @@ plex:                                           # Can be individually specified 
   db_cache:
   verify_ssl:
 tmdb:                                           # REQUIRED for the script to run
-  apikey: {{ media_services.tmdb.api_key }}
+  apikey: {{ external_apis.tmdb.api_key }}
   language: en
   cache_expiration: 60
   region:

--- a/playbooks/individual/ocean/media/plex.yaml
+++ b/playbooks/individual/ocean/media/plex.yaml
@@ -85,13 +85,25 @@
       state: absent
     tags: [config, plex]
 
-  - name: Create preferences file
+  - name: Check for Plex preferences seed (gitignored bootstrap file, absent in CI)
+    ansible.builtin.stat:
+      path: "{{ files }}/config/preferences.xml"
+    delegate_to: localhost
+    become: false
+    register: plex_prefs_seed
+    tags: [config, plex]
+
+  # Plex generates Preferences.xml (server identity + token) on first run and it
+  # must not be clobbered on every deploy; the seed is gitignored so it is absent
+  # on the CI runner. Only template it for a genuine first-time bootstrap.
+  - name: Create preferences file (first-time bootstrap only; skipped when seed absent)
     ansible.builtin.template:
       src: "{{ files }}/config/preferences.xml"
       dest: "{{ plex_home }}/config/Library/Application Support/Plex Media Server/Preferences.xml"
       mode: '0644'
       owner: "{{ user }}"
       group: "{{ user }}"
+    when: plex_prefs_seed.stat.exists
     register: plex_preferences_result
     tags: [config, plex]
 
@@ -140,7 +152,7 @@
 
   - name: Create meta_manager_home preferences file
     ansible.builtin.template:
-      src: "{{ files }}/meta-manager/config.yml"
+      src: "{{ files }}/meta-manager/config.yml.j2"
       dest: "{{ meta_manager_home }}/config/config.yml"
       mode: '0644'
       owner: "{{ user }}"


### PR DESCRIPTION
plex.yaml has been **un-deployable via CI** — it aborts at task 4 "Create preferences file" because `Preferences.xml` is a gitignored Plex-identity secret that is absent on the runner. That is why the Kometa migration (#157) could not deploy through CI and I applied it directly to the container.

**Fixes:**
1. **preferences.xml** — guard behind a controller-side `stat` of the seed; only template it for a genuine first-time bootstrap. Plex generates and owns `Preferences.xml` (server identity + token) after that and it must never be clobbered on a redeploy. Absent seed (CI) → task skips, playbook proceeds.
2. **meta-manager config** — deploy from the tracked `config.yml.j2` template (secrets from vault) instead of the gitignored rendered `config.yml`. Also fixed the TMDb key path: `media_services.tmdb.api_key` → `external_apis.tmdb.api_key` (where it actually lives in vault; the old path was undefined). `owner: {{ user }}` = `media` (uid 1001) matches Kometa's user.

After this, plex.yaml deploys end-to-end via CI, including the Kometa config + compose.

**Heads-up:** merging + deploying this runs the full plex.yaml, which will **restart the Plex container and PMM** (brief). The config/image it renders match what I already applied to the host, so it converges cleanly. I'll watch the deploy when you merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)