### PR TITLE
security(arr): vault sonarr/radarr/prowlarr API keys

### DIFF
--- a/files/ocean-prowlarr/prowlarr-exporter.service.j2
+++ b/files/ocean-prowlarr/prowlarr-exporter.service.j2
@@ -23,7 +23,7 @@ ExecStart=docker run --rm \
     -e VERSION=${VERSION} \
     -e PORT={{ exporter_port }} \
     -e URL="http://ocean.home:{{ prowlarr_port }}" \
-    -e APIKEY="83e44c481a5d4060a3c8f9214ed3fba5" \
+    -e APIKEY="{{ media_services.prowlarr.api_key }}" \
     -e ENABLE_ADDITIONAL_METRICS=true \
     -p {{ exporter_port }}:9710 \
     {{ exporter_image }}:{{ exporter_version }} prowlarr

--- a/files/ocean-radarr/config.xml.j2
+++ b/files/ocean-radarr/config.xml.j2
@@ -5,7 +5,7 @@
   <BindAddress>*</BindAddress>
   <SslPort>9898</SslPort>
   <EnableSsl>False</EnableSsl>
-  <ApiKey>eb727e9d30f540d59677e7cc08161da4</ApiKey>
+  <ApiKey>{{ media_services.radarr.api_key }}</ApiKey>
   <AuthenticationMethod>Basic</AuthenticationMethod>
   <Branch>master</Branch>
   <LaunchBrowser>False</LaunchBrowser>

--- a/files/ocean-radarr/radarr-exporter.service.j2
+++ b/files/ocean-radarr/radarr-exporter.service.j2
@@ -20,7 +20,7 @@ ExecStart=docker run --rm \
     -e VERSION={{ exporter_version }} \
     -e URL=http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ radarr_port }} \
     -e PORT={{ exporter_port }} \
-    -e APIKEY="eb727e9d30f540d59677e7cc08161da4" \
+    -e APIKEY="{{ media_services.radarr.api_key }}" \
     -e ENABLE_ADDITIONAL_METRICS=true \
     -p {{ exporter_port }}:{{ exporter_port }} \
   {{ exporter_image }}:{{ exporter_version }} \

--- a/files/ocean-sonarr/config.xml.j2
+++ b/files/ocean-sonarr/config.xml.j2
@@ -4,7 +4,7 @@
   <BindAddress>*</BindAddress>
   <SslPort>9898</SslPort>
   <EnableSsl>False</EnableSsl>
-  <ApiKey>f04a996effa8494aa68712bdb0b33a6f</ApiKey>
+  <ApiKey>{{ media_services.sonarr.api_key }}</ApiKey>
   <AuthenticationMethod>Basic</AuthenticationMethod>
   <Branch>main</Branch>
   <LaunchBrowser>True</LaunchBrowser>

--- a/files/ocean-sonarr/sonarr-exporter.service.j2
+++ b/files/ocean-sonarr/sonarr-exporter.service.j2
@@ -23,7 +23,7 @@ ExecStart=docker run --rm \
     -e PORT={{ exporter_port }} \
     -e ENABLE_ADDITIONAL_METRICS=true \
     -p {{ exporter_port }}:{{ exporter_port }} \
-    -e APIKEY="f04a996effa8494aa68712bdb0b33a6f" \
+    -e APIKEY="{{ media_services.sonarr.api_key }}" \
     {{ exporter_image }}:{{ exporter_version }} \
       sonarr
 ExecStop=docker rm -f %N

--- a/playbooks/individual/ocean/media/prowlarr.yaml
+++ b/playbooks/individual/ocean/media/prowlarr.yaml
@@ -4,6 +4,7 @@
   become: true
   vars_files:
     - "{{ playbook_dir }}/../../../../vars/vars_service_ports.yaml"
+    - "{{ playbook_dir }}/../../../../vault/secrets.yaml"
 
   vars:
     service: prowlarr

--- a/playbooks/individual/ocean/media/radarr.yaml
+++ b/playbooks/individual/ocean/media/radarr.yaml
@@ -4,6 +4,7 @@
   become: true
   vars_files:
     - "{{ playbook_dir }}/../../../../vars/vars_service_ports.yaml"
+    - "{{ playbook_dir }}/../../../../vault/secrets.yaml"
 
   vars:
     service: radarr


### PR DESCRIPTION
All four background *arr investigators flagged the same class of issue: API keys committed in plaintext to config/exporter templates.

This PR moves the **live** template keys (sonarr, radarr, prowlarr) to the vault, which already held identical values.

- `files/ocean-{sonarr,radarr,prowlarr}/*`: literal key -> `{{ media_services.<svc>.api_key }}`
- `radarr.yaml`/`prowlarr.yaml`: add `vault/secrets.yaml` to `vars_files` (only sonarr loaded it before)

Because the vault value equals the old literal, rendered `config.xml`/exporter env is byte-identical -> Ansible sees no file change -> **no container restart**.

Deferred (separate decision): bazarr `config.ini.j2` is a dead template (bazarr 1.6 reads `config.yaml`); it carries an opensubtitles password + flask_secret_key needing new vault entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)