### PR TITLE
fix(docker): wire Hub registry-cache mirror + rolling fleet restart [HELD - needs maintenance window]

### DIFF
--- a/playbooks/individual/infrastructure/docker_ce.yaml
+++ b/playbooks/individual/infrastructure/docker_ce.yaml
@@ -1,5 +1,8 @@
 - name: Install Docker CE on Debian 12
-  hosts: all
+  # Exclude the CI runner host: this play restarts dockerd, and the deploy runs
+  # inside a container on gh-runner-01 (group github_runners). Restarting docker
+  # there kills the running job. Runner-host docker changes are applied manually.
+  hosts: 'all:!github_runners'
   # Roll one host at a time: the daemon.json handler restarts dockerd, which
   # bounces every container on the host. Never bounce the whole fleet at once.
   serial: 1

--- a/playbooks/individual/infrastructure/docker_ce.yaml
+++ b/playbooks/individual/infrastructure/docker_ce.yaml
@@ -1,5 +1,9 @@
 - name: Install Docker CE on Debian 12
   hosts: all
+  # Roll one host at a time: the daemon.json handler restarts dockerd, which
+  # bounces every container on the host. Never bounce the whole fleet at once.
+  serial: 1
+  max_fail_percentage: 0
   become: yes
   vars_files:
     - ../../../vault/secrets.yaml
@@ -111,6 +115,7 @@
       owner: root
       group: root
       mode: '0644'
+    notify: restart docker
 
   - name: Ensure docker service override directory exists
     ansible.builtin.file:


### PR DESCRIPTION
**DO NOT MERGE until a maintenance window.** Merging triggers main-apply, which will restart dockerd across the whole fleet (one host at a time), bouncing every container — Plex, all media, GitLab, Nextcloud, etc.

## Why
The container registry cache stores almost nothing because the Docker Hub mirror was never active on the hosts:
- ocean `daemon.json` is frozen at 2025-11-27 with no `registry-mirrors`.
- The mirror line was added to `files/docker/daemon.json.j2` on 2026-05-24 but never reached the hosts.
- Root cause: the daemon.json write task in `docker_ce.yaml` never notified `restart docker`, so even when the file changed, the running daemon never picked it up.

## Changes
- `docker_ce.yaml`: add `notify: restart docker` to the authoritative daemon.json copy task (the jq-formatted write, not the raw template task — notifying the template task would fire every run since raw != formatted on disk).
- Add `serial: 1` + `max_fail_percentage: 0` so the fleet-wide dockerd restart rolls one host at a time and halts on first failure.

## Scope / expected benefit
Mirror caches **Docker Hub** pulls only — the `linuxserver/*` media stack, Plex, Jellyfin, GitLab, Nextcloud, Grafana, Prometheus, ComfyUI (~17 distinct Hub images that re-pull `:latest` weekly). ghcr/lscr.io images bypass it by design (Docker `registry-mirrors` is Hub-only). Benefit is Hub rate-limit/outage resilience + faster weekly recycles, not bandwidth.

## Deploy plan (when windowed)
1. Merge → main-apply runs docker_ce.yaml serial:1.
2. Watch health gate per host; halt-and-alert on unhealthy, no auto-rollback.
3. Verify `docker info | grep 'Registry Mirrors'` shows `registry-cache.home:5001` and `registry_cache_size_bytes` grows after the next pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)