### PR TITLE
fix(docker): remove deprecated nvidia-docker debian10 repos blocking ocean apt

### DIFF
--- a/playbooks/individual/infrastructure/docker_ce.yaml
+++ b/playbooks/individual/infrastructure/docker_ce.yaml
@@ -14,6 +14,15 @@
     docker_keyring_path: /etc/apt/keyrings/docker.asc
 
   tasks:
+  # Deprecated nvidia-docker debian10 repos ship an unsigned/rotated key
+  # (NO_PUBKEY DDCAE044F796ECB0) that makes every apt update fail. The current
+  # nvidia-container-toolkit repo (added later in this play) supersedes them, so
+  # remove the stale list before the first cache update. Absent elsewhere = no-op.
+  - name: Remove deprecated nvidia-docker debian10 apt repos
+    ansible.builtin.file:
+      path: /etc/apt/sources.list.d/nvidia-docker.list
+      state: absent
+
   - name: Install prerequisite packages
     apt:
       name:


### PR DESCRIPTION
Fix-forward for the halted registry-mirror deploy (run 29660748359), which failed on ocean at the first apt update.

## Root cause
ocean has `/etc/apt/sources.list.d/nvidia-docker.list` pointing at the EOL `debian10` nvidia repos (libnvidia-container, nvidia-container-runtime, nvidia-docker) with **no signed-by** and a rotated key:
```
GPG error nvidia.github.io/.../debian10 InRelease: NO_PUBKEY DDCAE044F796ECB0 ... is not signed
```
Every `apt update` on ocean fails, aborting the whole `docker_ce.yaml` roll there (serial:1 + max_fail_percentage:0). The modern `nvidia-container-toolkit.list` (proper `/deb/` path + keyring) is already present and added later in this same play, so the old list is broken **and** redundant.

## Change
- New first task in `docker_ce.yaml`: remove `nvidia-docker.list` (`state: absent`) before the first `update_cache`. No-op on hosts that never had it.

## Impact of merging
Re-runs `docker_ce.yaml` (hosts `all:!github_runners`, serial:1). node005/node006 are idempotent now (daemon.json unchanged → no restart). This completes the mirror on **ocean** (restarts ocean's dockerd → **bounces Plex + all media once**) and any hosts after ocean that never ran.

## Related latent hazard (not fixed here)
`nvidia_containerd.yaml:71` curls a deprecated `debian11` nvidia-docker.list (guarded by `creates:`). It is not triggered by this deploy and is not actively managing ocean's file, but if that playbook is ever run it would re-introduce a broken repo. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)