### PR TITLE
fix(docker): stop GPU-host dist-upgrade that surprise-bumped nvidia + broke Plex

### DIFF
--- a/playbooks/individual/infrastructure/docker_ce.yaml
+++ b/playbooks/individual/infrastructure/docker_ce.yaml
@@ -272,13 +272,6 @@
         update_cache: yes
       when: cuda_keyring_installed is changed
 
-    - name: Upgrade NVIDIA driver packages to latest (CUDA 12.6+ support)
-      ansible.builtin.apt:
-        upgrade: full
-        update_cache: yes
-      register: nvidia_upgrade_result
-      changed_when: "'nvidia' in nvidia_upgrade_result.stdout"
-
     - name: Install NVIDIA cuda-drivers package (includes nvidia-smi)
       ansible.builtin.apt:
         name: cuda-drivers
@@ -360,7 +353,7 @@
     - name: Determine if reboot is needed
       ansible.builtin.set_fact:
         reboot_needed: >-
-          {{ nvidia_upgrade_result is changed or 
+          {{ cuda_drivers_install is changed or
              nvidia_smi_check_post_upgrade.rc != 0 or
              current_driver_version.stdout is version('580', '<') }}
 


### PR DESCRIPTION
## Root cause of the ocean/Plex incident
`docker_ce.yaml`'s `Upgrade NVIDIA driver packages to latest` task ran `apt upgrade: full` (a whole-host dist-upgrade) inside the `nvidia_gpu` block. On ocean it bumped the driver **580 → 610.43.02** (bleeding edge). Because `reboot_needed` keyed off that task's `changed` state, ansible auto-rebooted ocean mid-play; Plex then crash-looped on `NVML: Driver/library version mismatch` (kernel module 580 vs userspace 610) until recovery.

## Change (+1/-8)
- Remove the `upgrade: full` task.
- Repoint `reboot_needed` from `nvidia_upgrade_result` → the existing `cuda_drivers_install` register.

The `cuda-drivers` metapackage still installs the driver on fresh GPU hosts (and the reboot task still fires to load it). Existing hosts: no dist-upgrade, no surprise version bump, and `reboot_needed` is false on re-runs (cuda-drivers unchanged, nvidia-smi OK, version ≥ 580).

## Deploy impact
Re-running `docker_ce.yaml` also **completes the mirror rollout** the failed run left half-done. Verified mirror-present: node005/node006/ocean/dns01/registry-cache-01. **Missing: agentbox, dns02** (pihole unreachable as terrac). Those get the mirror + a docker restart; serial:1 keeps DNS available (dns01 up while dns02 bounces). ocean is a **safe no-op**: daemon.json unchanged (no docker restart), no dist-upgrade, no reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)