### PR TITLE
fix(logging): RAM-only journals with a hard cap; purge on-disk journal

### DIFF
--- a/playbooks/individual/base/logging.yaml
+++ b/playbooks/individual/base/logging.yaml
@@ -56,11 +56,21 @@
         StandardError=journal
         Compress=true
         LineMax=10K
-        SystemMaxUse=500M
-        SystemMaxFileSize=100M
-        SystemMaxFiles=5
+        # Storage=volatile keeps journals in RAM (/run/log/journal); the
+        # Runtime* caps bound that RAM use. SystemMax* only applies to on-disk
+        # /var/log/journal, which volatile never uses, so it is not set here.
+        RuntimeMaxUse=100M
+        RuntimeMaxFileSize=20M
+        RuntimeMaxFiles=5
         MaxRetentionSec=2week
         ForwardToSyslog=false
+    notify:
+    - Restart systemd-journald
+
+  - name: Purge on-disk journal so journals live in RAM only (Storage=volatile)
+    ansible.builtin.file:
+      path: /var/log/journal
+      state: absent
     notify:
     - Restart systemd-journald
 


### PR DESCRIPTION
Implements the intended behavior: **systemd journals live in RAM only, hard-capped, never written to disk.**

## Problem
`journald.conf` already sets `Storage=volatile` (RAM at `/run/log/journal`), but the only size caps were `SystemMax*`, which apply to the on-disk `/var/log/journal` that volatile never uses. Net effect: the RAM journal was uncapped, and stale `/var/log/journal` files lingered. On the 11G DNS VMs those on-disk journals grew to ~0.8-1G and filled the root fs, which crashed the containerized PowerDNS stack (SQLite `disk I/O error`) and cascaded to a CI-runner outage (gh-runner-01's sole resolver is dns01).

## Change (`base/logging.yaml`, hosts: all)
- Replace `SystemMaxUse/SystemMaxFileSize/SystemMaxFiles` with `RuntimeMaxUse=100M` / `RuntimeMaxFileSize=20M` / `RuntimeMaxFiles=5` — the caps that actually bound a volatile (RAM) journal.
- Add a task to remove `/var/log/journal` so nothing persists to disk.

## Impact
Fleet-wide. Deploy rewrites journald.conf, purges `/var/log/journal`, and restarts `systemd-journald` (non-disruptive) on each host. Persistent log history is unaffected — promtail ships everything to Loki.

Companion actions (already applied manually): both DNS VM disks grown 11G→20G (dns01 50%, dns02 46%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)