### PR TITLE
feat(alerts): 3-tier disk monitoring (early warning + predictive fill)

### DIFF
--- a/files/ocean-prometheus/alert_rules.yml.j2
+++ b/files/ocean-prometheus/alert_rules.yml.j2
@@ -34,15 +34,39 @@ groups:
       summary: "High memory usage on hypervisor {{ "{{ $labels.instance }}" }}"
       description: "Memory usage is above 95% for more than 5 minutes on hypervisor {{ "{{ $labels.instance }}" }}"
 
-  # High disk usage alert
+  # Disk space: warn early, critical near-full, and predict rapid fills.
+  # Uses avail_bytes (what df/apps actually see, excludes root-reserved blocks)
+  # and ignores ephemeral filesystems (tmpfs/overlay/etc).
+  - alert: DiskSpaceWarning
+    expr: (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"}) * 100 > 80
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Disk over 80% on {{ "{{ $labels.instance }}" }} ({{ "{{ $labels.mountpoint }}" }})"
+      description: "{{ "{{ $labels.mountpoint }}" }} on {{ "{{ $labels.instance }}" }} is {{ "{{ $value }}" }}% used."
+
   - alert: HighDiskUsage
-    expr: (node_filesystem_size_bytes - node_filesystem_free_bytes) / node_filesystem_size_bytes * 100 > 90
+    expr: (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"}) * 100 > 90
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "High disk usage on {{ "{{ $labels.instance }}" }}"
-      description: "Disk usage is above 90% on filesystem {{ "{{ $labels.mountpoint }}" }} on {{ "{{ $labels.instance }}" }}"
+      summary: "Disk over 90% on {{ "{{ $labels.instance }}" }} ({{ "{{ $labels.mountpoint }}" }})"
+      description: "{{ "{{ $labels.mountpoint }}" }} on {{ "{{ $labels.instance }}" }} is {{ "{{ $value }}" }}% used - risk of service failure."
+
+  # Catch steady fills (e.g. growing journals/logs) before they hit the threshold.
+  - alert: DiskWillFillSoon
+    expr: |
+      predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"}[6h], 24 * 3600) < 0
+      and
+      (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs|ramfs|fuse.*"}) * 100 > 60
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Disk filling on {{ "{{ $labels.instance }}" }} ({{ "{{ $labels.mountpoint }}" }})"
+      description: "{{ "{{ $labels.mountpoint }}" }} on {{ "{{ $labels.instance }}" }} is projected to run out of space within 24h at the current rate."
 
   # Service down alert (excluding all blackbox probes)
   - alert: ServiceDown


### PR DESCRIPTION
Follow-up to the dns01/dns02 disk-full incident: the existing disk alert existed but didn't prevent it.

## Why the old rule missed it
`HighDiskUsage` used `node_filesystem_free_bytes` (includes root-reserved blocks), so it read lower than df/apps - dns01 at df-92% wasn't even firing. It also fired only at a flat 90% with no early warning and no rate-of-fill detection, and had no filesystem filter (noisy on overlay/tmpfs).

## New rules (`alert_rules.yml.j2`)
- **DiskSpaceWarning** (warning, 80%, 15m) - early lead time.
- **HighDiskUsage** (critical, 90%, 5m) - now using `avail_bytes`.
- **DiskWillFillSoon** (warning) - `predict_linear(avail[6h], 24h) < 0` guarded to >60% used; catches steady fills like the journal creep *before* they hit the threshold.

All use `node_filesystem_avail_bytes` (matches df) and exclude ephemeral filesystems (`tmpfs|overlay|squashfs|ramfs|fuse.*`). Prometheus-only change; reloads rules, no service restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)