### PR TITLE
feat(agentbox): auto-close alert issues on resolve (complete the loop)

### DIFF
--- a/files/agentbox/alert-receiver.py
+++ b/files/agentbox/alert-receiver.py
@@ -7,7 +7,8 @@ Alertmanager POSTs its webhook JSON here. For each FIRING alert we:
   - push a notification to ntfy so a human is aware (all severities);
   - open a GitHub issue on the infra repo so it becomes trackable/fixable —
     critical alerts get `needs-claude` (premium lane / drive via RC), others get
-    a plain issue. Resolved alerts just push a "resolved" ntfy.
+    a plain issue. Resolved alerts close the matching tracking issue (by
+    fingerprint) and push a "resolved" ntfy — completing the fire->fix->close loop.
 
 Deliberately dependency-free (stdlib only) and single-file: it reads config from
 the environment (rendered into the systemd unit) and shells out to `gh`.
@@ -65,6 +66,26 @@ def issue_exists(fp):
         return len(json.loads(r.stdout or "[]")) > 0
     except json.JSONDecodeError:
         return True
+
+
+def close_issue(alert):
+    """Resolve half of the loop: close the open tracking issue(s) carrying this
+    alert's fingerprint when Alertmanager reports it resolved."""
+    fp = alert.get("fingerprint", alert["labels"].get("alertname", "unknown"))
+    r = gh("issue", "list", "--repo", ISSUE_REPO, "--state", "open",
+           "--search", f"{FP_MARKER}{fp} in:body", "--json", "number")
+    if r.returncode != 0:
+        print(f"gh issue list failed (close): {r.stderr.strip()}", flush=True)
+        return
+    try:
+        nums = [i["number"] for i in json.loads(r.stdout or "[]")]
+    except json.JSONDecodeError:
+        return
+    for num in nums:
+        c = gh("issue", "close", str(num), "--repo", ISSUE_REPO,
+               "--reason", "completed",
+               "--comment", "Alert resolved in Alertmanager; auto-closing.")
+        print((c.stdout or c.stderr).strip(), flush=True)
 
 
 def open_issue(alert):
@@ -135,6 +156,7 @@ def handle(payload):
             if num and sev == "critical" and REMEDIATE:
                 remediate(num)
         else:
+            close_issue(alert)
             ntfy(f"resolved: {name}", f"{inst}\n{summary}".strip(),
                  "min", "white_check_mark,homelab")
 


### PR DESCRIPTION
Completes the Alertmanager -> issue -> agentbox-fixes -> **close** cycle.

## Gap
`files/agentbox/alert-receiver.py` opened a fingerprint-tagged GitHub issue on a **firing** alert (deduped via the `<!-- alert-fp:{fp} -->` marker), and the issue-watcher/escalate lane worked those issues into PRs. But on **resolved** it only pushed a 'resolved' ntfy — issues never closed, so they accumulated (this is why old alert issues like #122 linger).

## Change (one file)
- Add `close_issue(alert)`: search open issues for the alert's `alert-fp:{fingerprint}`, `gh issue close --reason completed` each with a comment.
- Call it in the resolved branch before the ntfy.

Firing and resolved webhooks share Alertmanager's stable `fingerprint`, so the resolve reliably matches the issue opened on fire. Verified with a mock: resolved alert -> searches `alert-fp:<fp> in:body` -> closes the matched issue.

Deploys to agentbox (renders the receiver + restarts the unit). Pre-existing already-resolved issues are closed out-of-band (they predate this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)