### PR TITLE
fix(docker): gate media user/group creation on manage_service_users

### DIFF
--- a/playbooks/individual/infrastructure/docker_ce.yaml
+++ b/playbooks/individual/infrastructure/docker_ce.yaml
@@ -82,6 +82,7 @@
       name: media
       gid: "{{ system_users.media.gid }}"
       state: present
+    when: manage_service_users | default(true) | bool
 
   - name: Create media user with UID from vault
     ansible.builtin.user:
@@ -93,6 +94,7 @@
       home: /home/media
       create_home: yes
       state: present
+    when: manage_service_users | default(true) | bool
 
   - name: Add terrac user to docker group
     ansible.builtin.user:


### PR DESCRIPTION
Unblocks the fleet `docker_ce.yaml` roll, which currently fails on pihole.

## Problem
`docker_ce.yaml:80-95` creates the `media` group/user at GID/UID 1001 on **every** host. On pihole, GID 1001 is already the `pihole` group (`getent group 1001` -> `pihole:x:1001:`), so `groupadd` fails with `GID '1001' already exists` and aborts the serial roll there — the mirror rollout can't finish past pihole.

## Fix
Add `when: manage_service_users | default(true) | bool` to both media tasks. pihole (and other appliance hosts) set `manage_service_users=false` in inventory (`hosts.ini:16`); `base/users.yaml` already gates its `service_users` on this exact flag. This aligns docker_ce with that pattern.

## Effect
- pihole: media tasks skip -> no GID 1001 collision -> docker_ce completes; pihole's `pihole` group is untouched (it runs no media services and never needed a `media` group).
- All other hosts (flag unset -> default true): unchanged.

Merging re-runs docker_ce.yaml fleet-wide (serial:1, all:!github_runners) and should complete past pihole, finishing the registry-mirror rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)