### PR TITLE
fix: [alert] ServiceDown on ocean.home (#197)

### DIFF
--- a/files/ocean-plex/plex-compose.yml.j2
+++ b/files/ocean-plex/plex-compose.yml.j2
@@ -71,10 +71,16 @@ services:
     environment:
       PLEX_ADDR: http://plex:32400
       PLEX_TOKEN: "{{ media_services.plex.api_key }}"
-      # Keep below Prometheus scrape_timeout (default 10s) so scrapes don't
-      # time out while the exporter waits on a hung Plex.
+      # The exporter queries Plex synchronously on each /metrics scrape, so its
+      # worst-case wait is PLEX_TIMEOUT * PLEX_RETRIES_COUNT. The plex-exporter
+      # scrape job sets scrape_timeout: 15s; 5s * 3 = 15s left zero margin, so a
+      # hung Plex stalled the scrape past 15s and Prometheus marked the
+      # *exporter* down (a misleading ServiceDown) instead of the exporter
+      # reporting plex_up=0 (the dedicated PlexDown alert). Drop retries to 1 so
+      # the worst case (~5s) stays well under scrape_timeout and scrapes always
+      # return in time.
       PLEX_TIMEOUT: "5"
-      PLEX_RETRIES_COUNT: "3"
+      PLEX_RETRIES_COUNT: "1"
       PLEX_SSL_VERIFY: "false"
       RACK_ENV: "production"
     ports:
@@ -92,7 +98,13 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 256M
+          # This Ruby/Rack exporter loads Plex library data into memory when it
+          # collects media metrics; on a large library the 256M cap it shipped
+          # with gets OOM-killed mid-collection, and the resulting restart loop
+          # left the :9594 endpoint unreachable during Prometheus scrapes
+          # (up==0 -> ServiceDown). Raise the ceiling well clear of the working
+          # set; the host has 351G, so 1G is still a hard, safe bound.
+          memory: 1G
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:{{ exporter_port }}/metrics"]
       interval: 30s

--- a/playbooks/individual/ocean/media/plex.yaml
+++ b/playbooks/individual/ocean/media/plex.yaml
@@ -190,6 +190,19 @@
       state: started
     tags: [service, meta-manager]
 
+  # Guarantee the plex compose stack (which contains the plex-exporter
+  # container) is enabled and running on every deploy, not just when a config
+  # or service file changed. Without this, a no-op deploy or a host reboot left
+  # plex.service down, so plex-exporter never came up and Prometheus reported
+  # ServiceDown on ocean.home:9594. Mirrors the meta-manager enable above.
+  - name: Enable and start plex service
+    ansible.builtin.systemd:
+      name: plex.service
+      enabled: true
+      state: started
+      daemon_reload: yes
+    tags: [service, plex]
+
   - name: Reload systemd daemon if plex service changed
     ansible.builtin.systemd:
       daemon_reload: yes


### PR DESCRIPTION
Resolves #197. Shipped by the Claude Code premium lane.