### PR TITLE
fix(plex): pin plex-exporter to 2.1.0 (:latest frozen at buggy 1.0.0)

### DIFF
--- a/playbooks/individual/ocean/media/plex.yaml
+++ b/playbooks/individual/ocean/media/plex.yaml
@@ -42,7 +42,10 @@
     - /dev/nvidiactl
     exporter_service: plex-exporter
     exporter_image: ghcr.io/axsuul/plex-media-server-exporter
-    exporter_version: latest
+    # Pin an explicit release: upstream's :latest tag is frozen at 1.0.0 (2023-11-10),
+    # which predates the media-downloads username fix (1.1.3) and emits a :user label
+    # that collides with :username, 500-ing /metrics. 2.1.0 is the current release.
+    exporter_version: "2.1.0"
     exporter_port: "{{ service_ports.plex_exporter.port }}"
     meta_manager_service: plex-meta-manager
     meta_manager_image: kometateam/kometa


### PR DESCRIPTION
## What
Pin `exporter_version` for plex-exporter from `latest` to `2.1.0`.

## Why
Paged: `ServiceDown` critical, `plex-exporter` on `ocean.home`. The exporter container was `Up (unhealthy)`, `/metrics` returning HTTP 500:
```
InvalidLabelSetError: labels must have the same signature
(keys given: [:user_id, :user] vs. keys expected: [:user_id, :username])
```
Root cause: upstream's GHCR `:latest` tag is **frozen at release 1.0.0** (image built 2023-11-10, `docker pull` reports "up to date"). 1.0.0 predates the `Fix username for media downloads` commit shipped in **1.1.3** (2023-11-20). The stale build emits a `:user` label where the metric registered `:username`, so the Ruby prometheus client rejects the whole render → 500 → healthcheck fail → scrape fail → ServiceDown. A restart could never fix it: the compose service uses `image: ...:latest` with no pull policy, so it kept re-running the cached 1.0.0.

Verified `collector.rb` at tag `2.1.0` uses `:username` consistently (no `:user`).

## Blast radius
- Host: **ocean** only. Service: plex-exporter (:9594).
- The version lives in the shared `plex-compose.yml.j2`, so `plex_compose_result is changed` fires the `Restart plex service` handler — **the plex compose stack (Plex included) restarts briefly**. No active Plex sessions at deploy prep time.
- 2.1.0 is a new tag not cached on ocean, so compose pulls it on `up`.

## Note
The page is silenced in Alertmanager for a 90m ship window (silence `27b69023`); it resolves on its own once the deploy lands and `/metrics` returns 200.