### PR TITLE
fix(runners): daily docker prune timer + drop stray root-owned .env

### DIFF
--- a/roles/github_docker_runners/defaults/main.yml
+++ b/roles/github_docker_runners/defaults/main.yml
@@ -85,6 +85,10 @@ github_runner_cloudflared_url: "https://github.com/cloudflare/cloudflared/releas
 github_runners_compose_file: "{{ github_runners_base_dir }}/docker-compose.yml"
 github_runners_service_name: "github-docker-runners"
 
+# Docker image/build-cache prune schedule (systemd OnCalendar syntax).
+# Keeps the runner host's local image store from growing until the disk fills.
+github_runner_docker_prune_on_calendar: "daily"
+
 # Runner container resource limits (optional)
 # Uncomment to set CPU and memory limits per container
 # github_runner_cpus: "2.0"

--- a/roles/github_docker_runners/tasks/main.yml
+++ b/roles/github_docker_runners/tasks/main.yml
@@ -222,6 +222,51 @@
     enabled: true
     state: started
 
+# The compose stack reads GITHUB_TOKEN from the systemd EnvironmentFile
+# (.github_token_env). A stray root-owned .env in the working dir shadows that
+# and, because the service runs as the github-runner user, makes `docker compose`
+# fail with "open .env: permission denied" — which silently breaks the service's
+# ability to recreate runners (they survive only on Docker's restart:always until
+# something forces a recreate). Keep the working dir free of it.
+- name: Remove stray root-owned compose .env (token comes from EnvironmentFile)
+  ansible.builtin.file:
+    path: "{{ github_runners_base_dir }}/.env"
+    state: absent
+
+# Disk hygiene: ephemeral CI runs pull job images that accumulate unreferenced in
+# the local image store and eventually fill the disk (which corrupts a mid-flight
+# runner auto-update and takes CI down). A daily prune of unused images/build
+# cache caps the growth. Deliberately does NOT prune containers and does NOT
+# notify the runner restart handler, so applying this via CI never bounces the
+# runner that is running the deploy.
+- name: Template docker-prune oneshot service
+  ansible.builtin.template:
+    src: docker-prune.service.j2
+    dest: /etc/systemd/system/docker-prune.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload systemd daemon
+
+- name: Template docker-prune timer
+  ansible.builtin.template:
+    src: docker-prune.timer.j2
+    dest: /etc/systemd/system/docker-prune.timer
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload systemd daemon
+
+- name: Reload systemd so the prune units are known before enabling
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Enable and start the docker-prune timer
+  ansible.builtin.systemd:
+    name: docker-prune.timer
+    enabled: true
+    state: started
+
 - name: Display runner configuration summary
   ansible.builtin.debug:
     msg:

--- a/roles/github_docker_runners/templates/docker-prune.service.j2
+++ b/roles/github_docker_runners/templates/docker-prune.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prune unused Docker images and build cache (runner host disk hygiene)
+Documentation=https://docs.docker.com/engine/reference/commandline/image_prune/
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# -a removes every image not referenced by an existing container, so the runner
+# image and the exporter images (all have live containers) are kept, while the
+# job images that ephemeral runs pull and abandon are reclaimed. Container logs
+# go to journald (RAM-capped), so no on-disk log rotation is needed here.
+ExecStart=/usr/bin/docker image prune -af
+ExecStart=/usr/bin/docker builder prune -af

--- a/roles/github_docker_runners/templates/docker-prune.timer.j2
+++ b/roles/github_docker_runners/templates/docker-prune.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic Docker image/build-cache prune on the runner host
+
+[Timer]
+OnCalendar={{ github_runner_docker_prune_on_calendar }}
+# Persistent: if the host was off at the scheduled time, run once on next boot
+# so a powered-down runner does not skip cleanup and drift toward full.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What
Adds a daily `docker-prune.timer` to the `github_docker_runners` role and removes the stray root-owned `/opt/github-runners/.env`.

## Why (paged: DiskWillFillSoon on gh-runner-01)
- `docker system df` on gh-runner-01 showed **~10GB reclaimable** unused images. Ephemeral CI runs pull job images that accumulate unreferenced in the local image store, and **nothing ever prunes them** -> disk trends to full.
- The full disk then corrupted an in-flight GitHub runner **auto-update**, deleting `/actions-runner/bin/Runner.Listener` in the container writable layer -> all four runners crash-looped (`127`) -> **CI fully down** (all runners offline).
- Compounding it: a stray root-owned `.env` (`600 root:root`) in the compose dir. The service runs as `User=github-runner`, so `docker compose` failed with `open .env: permission denied` and **could not recreate the runners**. That is why a recoverable disk-full became a full outage.

## Fix
- `docker-prune.timer` (daily) -> `docker image prune -af` + `docker builder prune -af`. Images with live containers (runner + exporters) are kept; abandoned job images are reclaimed. Container logs go to journald (RAM-capped), so no on-disk log rotation needed.
- Remove `/opt/github-runners/.env` (`state: absent`). Token already comes from the systemd `EnvironmentFile` (`.github_token_env`).

## Already done manually (incident recovery, this is the durable version)
- Ad-hoc `docker image prune` freed ~6GB (70% -> 33%).
- Force-recreated the four runner containers (discarded corrupted writable layers); all 4 back **online**.
- Removed the stray `.env` (`.env.bak` backup left on host); service now `active`.

## Deploy safety
None of the new tasks notify the runner-restart handler, so applying via CI does **not** bounce the self-hosted runner running the deploy. Host: gh-runner-01 (`[github_runners]` group, production inventory).