### PR TITLE
fix(runners): disable in-container runner auto-update (DISABLE_AUTO_UPDATE)

### DIFF
--- a/roles/github_docker_runners/templates/docker-compose.yml.j2
+++ b/roles/github_docker_runners/templates/docker-compose.yml.j2
@@ -63,6 +63,7 @@ services:
 {% else %}
       EPHEMERAL: "false"
 {% endif %}
+      DISABLE_AUTO_UPDATE: "true"
       
       # Runner scope (for organization-level runners)
 {% if github_scope == 'org' %}


### PR DESCRIPTION
## What
Adds `DISABLE_AUTO_UPDATE: "true"` to the runner compose template.

## Why
Follow-up to #208. Recovering CI after the disk-fill revealed the *recurring* root cause of the runner crash-loop is **in-container auto-update**, not disk:
- Ephemeral runners auto-update on job pickup. The update renames `/actions-runner/bin` -> `bin.<version>` (confirmed via `docker diff`: `A /actions-runner/bin.2.335.1`, `SelfUpdate-…log`), and because the container exits mid/post-update and restarts, the new `bin` is never in place.
- `config.sh` then fails `./bin/Runner.Listener: No such file or directory` (127) -> all four runners crash-loop -> full CI outage. Reproduced with **18G free**, so disk was only the first trigger.

Fix: pin the runner to the image's runner version (`2.335.1`); bump by pulling a newer image tag, not by in-container self-update. Standard practice for containerized ephemeral runners.

## Already applied by hand on gh-runner-01
Per the manual-runner-change policy (a runner can't safely redeploy itself mid-job), this and the #208 timer were applied by hand: `DISABLE_AUTO_UPDATE` in compose + runners recreated (all 4 `online`, `Disable auto update option is enabled` in the log), the `docker-prune.timer` installed (`active`, next run 00:00), stray `.env` removed, disk 70% -> 26%.

## Deploy safety
The rendered compose **byte-matches** the hand-applied host file, so the role's compose task reports no change and does **not** restart the runner running the deploy. Verified whitespace parity locally.