### PR TITLE
fix: [alert] ServiceDown on ocean.home (#214)

### DIFF
--- a/.commitmsg.txt
+++ b/.commitmsg.txt
@@ -1,0 +1,17 @@
+fix(tautulli): don't health-gate exporter startup (ServiceDown #214)
+
+The tautulli-exporter container declared `depends_on: tautulli:
+condition: service_healthy`. `docker compose up -d` blocks until a
+service_healthy dependency reports healthy, but Tautulli's healthcheck
+(120s start_period + up to 5x30s retries) can exceed the systemd unit's
+TimeoutStartSec=180. When it does, systemd SIGTERMs the compose start
+before the exporter container is ever created, so Prometheus sees
+ocean.home:8913 down (ServiceDown critical) even though Tautulli itself
+is running fine.
+
+Downgrade to start-ordering only (`depends_on: - tautulli`). The
+exporter connects to Tautulli per-scrape and tolerates it being briefly
+unavailable, so it must stay independently scrapeable rather than be
+gated on Tautulli health.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/files/tautulli-compose/docker-compose.yml.j2
+++ b/files/tautulli-compose/docker-compose.yml.j2
@@ -71,10 +71,15 @@ services:
     networks:
       - plex_network
 
-    # Service dependencies - wait for Tautulli to be healthy
+    # Start-ordering only: do NOT gate on Tautulli's health. `up -d` blocks until
+    # a service_healthy dependency reports healthy, and Tautulli's healthcheck
+    # (120s start_period + 5x30s retries) can exceed the unit's TimeoutStartSec=180.
+    # When it does, systemd kills the compose start before this exporter is ever
+    # created, leaving it permanently down (ServiceDown) while Tautulli itself runs.
+    # The exporter connects to Tautulli per-scrape and tolerates it being briefly
+    # unavailable, so it must stay independently scrapeable.
     depends_on:
-      tautulli:
-        condition: service_healthy
+      - tautulli
 
     # Resource limits
     cpus: '0.5'


### PR DESCRIPTION
Resolves #214. Shipped by the Claude Code premium lane.