### PR TITLE
feat(plex): autoheal timer restarts container when unhealthy

### DIFF
--- a/files/ocean-plex/plex-autoheal.service.j2
+++ b/files/ocean-plex/plex-autoheal.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restart Plex container if Docker reports it unhealthy
+After=plex.service
+Wants=plex.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'if [ "$(/usr/bin/docker inspect -f {% raw %}{{.State.Health.Status}}{% endraw %} {{ service }} 2>/dev/null)" = "unhealthy" ]; then logger -t plex-autoheal "plex unhealthy, restarting"; /usr/bin/docker restart {{ service }}; fi'
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/files/ocean-plex/plex-autoheal.timer.j2
+++ b/files/ocean-plex/plex-autoheal.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Poll Plex health every 15 minutes and restart if unhealthy
+Requires=plex-autoheal.service
+
+[Timer]
+OnCalendar=*:0/15
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/playbooks/individual/ocean/media/plex.yaml
+++ b/playbooks/individual/ocean/media/plex.yaml
@@ -144,6 +144,17 @@
     register: plex_service_result
     tags: [service, plex]
 
+  - name: Create plex autoheal systemd units
+    ansible.builtin.template:
+      src: "{{ files }}/{{ item }}.j2"
+      dest: "/etc/systemd/system/{{ item }}"
+      mode: '0644'
+    with_items:
+    - plex-autoheal.service
+    - plex-autoheal.timer
+    register: plex_autoheal_result
+    tags: [service, plex]
+
   - name: Ensure meta-manager basedir exists
     ansible.builtin.file:
       path: "{{ meta_manager_home }}"
@@ -198,6 +209,14 @@
       daemon_reload: yes
     when: plex_service_result is defined and plex_service_result is changed
     tags: [restart, service, plex]
+
+  - name: Enable and start plex autoheal timer
+    ansible.builtin.systemd:
+      name: plex-autoheal.timer
+      state: started
+      enabled: true
+      daemon_reload: "{{ plex_autoheal_result is changed }}"
+    tags: [service, plex]
 
   - name: Reload systemd daemon if meta-manager service changed
     ansible.builtin.systemd:


### PR DESCRIPTION
## What
Adds a systemd timer on **ocean** that restarts the `plex` container every 15 min **only when Docker reports it `unhealthy`**.

## Why
Plex wedged overnight (SQLite maintenance deadlock): it stopped serving :32400 while the container stayed `Up`, so nothing restarted it and it sat dead ~13h. The container already has a working healthcheck (`curl -f http://localhost:32400/web/index.html`, unhealthy after 3x30s); this closes the loop by acting on that signal.

## How
- `files/ocean-plex/plex-autoheal.service.j2` - oneshot; restarts `{{ service }}` only if `.State.Health.Status == unhealthy`, else exits 0.
- `files/ocean-plex/plex-autoheal.timer.j2` - `OnCalendar=*:0/15`.
- `plex.yaml` - templates both units, enables+starts the timer. Mirrors the existing `cadvisor-restart` pattern.

## Blast radius
ocean only. Does not trip the playbook's plex restart handler (only compose/service/prefs changes do). Verified: healthy->no-op exit 0, unhealthy->restart; systemd passes the command substitution to sh intact (probed on ocean -> `RESULT=[healthy]`).