### PR TITLE
fix(ndt): stop M-Lab Locate 429s (cache servers, slow cadence, backoff)

### DIFF
--- a/files/ndt-speedtest-exporter/exporter.py
+++ b/files/ndt-speedtest-exporter/exporter.py
@@ -15,6 +15,7 @@ the others.
 import asyncio
 import json
 import os
+import random
 import time
 import urllib.request
 
@@ -24,10 +25,18 @@ from prometheus_client import Gauge, start_http_server
 SUBPROTO = "net.measurementlab.ndt.v7"
 LOCATE_URL = "https://locate.measurementlab.net/v2/nearest/ndt/ndt7"
 
-INTERVAL = int(os.environ.get("NDT_INTERVAL_SECONDS", "300"))
+INTERVAL = int(os.environ.get("NDT_INTERVAL_SECONDS", "1800"))
 DURATION = int(os.environ.get("NDT_TEST_SECONDS", "8"))
 PORT = int(os.environ.get("NDT_PORT", "9140"))
 MAX_SERVERS = int(os.environ.get("NDT_MAX_SERVERS", "4"))
+# M-Lab rate-limits fixed-interval "periodic" Locate callers per-IP (429 "too
+# many periodic requests"). Reuse the servers/tokens from one Locate response
+# across several test cycles instead of re-locating every cycle. LOCATE_TTL must
+# stay under the access-token lifetime (~2h); the all-fail path below forces an
+# early refresh if a token expires sooner.
+LOCATE_TTL = int(os.environ.get("NDT_LOCATE_TTL_SECONDS", "5400"))
+# +/- fraction of jitter on the sleep so we are not perfectly periodic.
+JITTER = float(os.environ.get("NDT_JITTER_FRACTION", "0.2"))
 
 LABELS = ["machine", "city", "country"]
 g_download = Gauge("ndt_download_mbps", "NDT7 download throughput (Mbps)", LABELS)
@@ -42,6 +51,30 @@ def locate_servers():
     with urllib.request.urlopen(LOCATE_URL, timeout=15) as r:
         data = json.load(r)
     return data.get("results", [])[:MAX_SERVERS]
+
+
+# Cached Locate result plus a backoff clock. On a Locate failure (typically 429)
+# we keep the last-known servers so the dashboard never blanks, and refuse to
+# re-hit Locate until cooldown_until, doubling the wait each consecutive failure.
+_locate = {"servers": [], "at": 0.0, "fails": 0, "cooldown_until": 0.0}
+
+
+def cached_servers():
+    now = time.time()
+    fresh = _locate["servers"] and now - _locate["at"] < LOCATE_TTL
+    if fresh or now < _locate["cooldown_until"]:
+        return _locate["servers"]  # reuse cache; or backing off -> stale/empty
+    try:
+        servers = locate_servers()
+        if servers:
+            _locate.update(servers=servers, at=now, fails=0, cooldown_until=0.0)
+        return _locate["servers"]
+    except Exception as e:
+        _locate["fails"] += 1
+        backoff = min(LOCATE_TTL, 300 * 2 ** (_locate["fails"] - 1))
+        _locate["cooldown_until"] = now + backoff
+        print(f"[err] locate failed (#{_locate['fails']}, backoff {backoff:.0f}s): {e}", flush=True)
+        return _locate["servers"]
 
 
 def _server_mbps(measurement, field="BytesAcked"):
@@ -151,15 +184,16 @@ async def test_server(result):
 
 async def cycle():
     start = time.monotonic()
-    try:
-        servers = locate_servers()
-    except Exception as e:
-        print(f"[err] locate failed: {e}", flush=True)
+    servers = cached_servers()
+    if not servers:
+        print("[warn] no servers available (locate rate-limited?)", flush=True)
         return
     results = [await test_server(s) for s in servers]  # serial: don't let tests contend
     g_cycle_seconds.set(round(time.monotonic() - start, 2))
     if results and all(results):
         g_last_success.set(time.time())
+    elif not any(results):
+        _locate["at"] = 0.0  # every server failed: tokens likely expired, re-locate next cycle
 
 
 def main():
@@ -167,7 +201,7 @@ def main():
     print(f"ndt-speedtest-exporter on :{PORT}, interval={INTERVAL}s, duration={DURATION}s", flush=True)
     while True:
         asyncio.run(cycle())
-        time.sleep(INTERVAL)
+        time.sleep(INTERVAL * (1 + random.uniform(-JITTER, JITTER)))
 
 
 if __name__ == "__main__":

--- a/playbooks/individual/ocean/monitoring/ndt_speedtest.yaml
+++ b/playbooks/individual/ocean/monitoring/ndt_speedtest.yaml
@@ -1,9 +1,10 @@
 ---
 # NDT7 (M-Lab) multi-location speed-test exporter. Replaces the retired
 # bluefishforsale/ndt-speedtest-exporter. Builds a small python image on ocean
-# and runs it as a systemd docker service; Prometheus scrapes :9140 every 5m,
-# which is also the test cadence (NDT7 tests are light, so 5m does not saturate
-# the link).
+# and runs it as a systemd docker service; Prometheus scrapes :9140. Tests run
+# every 30m (with jitter): M-Lab rate-limits fixed-interval callers of its
+# Locate API per-IP (429), so the exporter caches Locate results and re-locates
+# at most a few times an hour rather than every cycle.
 - name: Deploy NDT speedtest exporter
   hosts: ocean
   become: true
@@ -15,7 +16,7 @@
     # Hardcoded (not vars_service_ports) so this deploy doesn't fan out to every
     # playbook that references that shared file. Matches the prometheus scrape job.
     ndt_exporter_port: 9140
-    ndt_exporter_interval: 300
+    ndt_exporter_interval: 1800
     ndt_exporter_max_servers: 4
     src: "{{ playbook_dir }}/../../../../files/ndt-speedtest-exporter"
     home: /data01/services/ndt-speedtest-exporter


### PR DESCRIPTION
## What
NDT speed-test dashboard went flat because the exporter is being **429'd by M-Lab's Locate API** (`too many periodic requests`). It called Locate every 5m with no caching/backoff, so M-Lab rate-limited our IP, returned no servers, and no tests ran (`ndt_last_success_timestamp_seconds 0.0`, zero download/upload series).

## How
`files/ndt-speedtest-exporter/exporter.py`:
- **Cache Locate results** and reuse the returned servers/access-tokens across cycles (`LOCATE_TTL` 90m, under token expiry). Cuts Locate calls from 288/day to ~16/day.
- **Slow the test cadence** 5m -> 30m and add **+/-20% jitter** so we are not a perfectly-periodic caller.
- **Exponential backoff** on Locate failure (300s -> 90m cap), keeping the last-known servers so the dashboard never blanks.
- An all-server-fail cycle forces an early re-locate (handles tokens expiring before TTL).

`ndt_speedtest.yaml`: `ndt_exporter_interval` 300 -> 1800; comment refreshed.

## Verified
py_compile + a logic test covering cache-reuse, TTL refresh, stale-on-failure, cooldown suppression, and backoff doubling (`300->600->1200->2400->4800->5400` cap). ansible syntax-check clean.

## Blast radius
ocean only; rebuilds the exporter image and restarts the service. Recovery of live data depends on M-Lab's rolling block clearing; the new exporter self-recovers (backoff + retry) once a Locate call succeeds.

## Caveat
If M-Lab's periodic limit is low enough that even ~16 Locate calls/day still 429, the sanctioned next step is registering a monitoring key with support@measurementlab.net.