### PR TITLE
fix(ndt): repair dashboard metrics + add Locate API status panel

### DIFF
--- a/files/grafana-compose/dashboards/NDT_Internet_Speed_Test_Dashboard.json
+++ b/files/grafana-compose/dashboards/NDT_Internet_Speed_Test_Dashboard.json
@@ -24,8 +24,207 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "bf02tpxiz6m0wf"
+        "uid": "${DS_PROMETHEUS}"
       },
+      "description": "HTTP status returned by the M-Lab Locate API on the last attempt. 429 = rate-limited (no servers, no tests). Watch it drop from 429 to 200 to see when the block clears.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "orange",
+                  "index": 2,
+                  "text": "Error"
+                },
+                "200": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "429": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Rate limited"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 500,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 400
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "ndt_locate_http_status",
+          "instant": false,
+          "legendFormat": "Locate HTTP status",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "M-Lab Locate API HTTP Status (429 = rate-limited)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Age of the last fully successful test cycle. Grows without bound while the exporter is blocked or failing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2400
+              },
+              {
+                "color": "red",
+                "value": 5400
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "time() - ndt_last_success_timestamp_seconds",
+          "instant": false,
+          "legendFormat": "Since last success",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Since Last Successful Test",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Best download across the M-Lab servers tested this cycle.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -63,7 +262,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 6
       },
       "id": 1,
       "options": {
@@ -89,14 +288,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "ndt_speedtest / 1000000",
+          "expr": "max(ndt_download_mbps)",
           "instant": false,
-          "legendFormat": "Current Speed",
+          "legendFormat": "Download",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Internet Speed (Current)",
+      "title": "Download (Current)",
       "type": "gauge"
     },
     {
@@ -104,6 +303,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Best download and upload across servers over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -123,7 +323,6 @@
             "hideFrom": {
               "legend": false,
               "tooltip": false,
-              "vis": false,
               "viz": false
             },
             "insertNulls": false,
@@ -150,10 +349,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -165,7 +360,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 6
       },
       "id": 2,
       "options": {
@@ -193,14 +388,26 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "ndt_speedtest / 1000000",
+          "expr": "max(ndt_download_mbps)",
           "instant": false,
-          "legendFormat": "Internet Speed",
+          "legendFormat": "Download",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(ndt_upload_mbps)",
+          "instant": false,
+          "legendFormat": "Upload",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Internet Speed Over Time",
+      "title": "Download & Upload Over Time",
       "type": "timeseries"
     },
     {
@@ -231,7 +438,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 9
+        "y": 15
       },
       "id": 3,
       "options": {
@@ -259,14 +466,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "ndt_speedtest / 1000000",
+          "expr": "max(ndt_download_mbps)",
           "instant": false,
-          "legendFormat": "Current",
+          "legendFormat": "Download",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Current Speed",
+      "title": "Download Now",
       "type": "stat"
     },
     {
@@ -297,7 +504,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 9
+        "y": 15
       },
       "id": 4,
       "options": {
@@ -308,220 +515,14 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.5.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "avg_over_time(ndt_speedtest[24h]) / 1000000",
-          "instant": false,
-          "legendFormat": "24h Average",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "24h Average Speed",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "Mbits"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 9
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.5.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "max_over_time(ndt_speedtest[24h]) / 1000000",
-          "instant": false,
-          "legendFormat": "Peak Speed",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "24h Peak Speed",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "Mbits"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 9
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "min"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.5.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "min_over_time(ndt_speedtest[24h]) / 1000000",
-          "instant": false,
-          "legendFormat": "Minimum Speed",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "24h Minimum Speed",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 13
-      },
-      "id": 7,
-      "options": {
-        "displayLabels": [
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
             "lastNotNull"
           ],
           "fields": "",
           "values": false
         },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.5.4",
       "targets": [
@@ -531,51 +532,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, rate(ndt_speedtest[1h]))",
+          "expr": "max(ndt_upload_mbps)",
           "instant": false,
-          "legendFormat": "95th Percentile",
+          "legendFormat": "Upload",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.75, rate(ndt_speedtest[1h]))",
-          "instant": false,
-          "legendFormat": "75th Percentile",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, rate(ndt_speedtest[1h]))",
-          "instant": false,
-          "legendFormat": "50th Percentile (Median)",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.25, rate(ndt_speedtest[1h]))",
-          "instant": false,
-          "legendFormat": "25th Percentile",
-          "range": true,
-          "refId": "D"
         }
       ],
-      "title": "Speed Distribution (Percentiles)",
-      "type": "piechart"
+      "title": "Upload Now",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -585,29 +550,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "vis": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
@@ -618,43 +561,42 @@
                 "value": null
               },
               {
+                "color": "yellow",
+                "value": 40
+              },
+              {
                 "color": "red",
                 "value": 80
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 4,
+        "w": 6,
         "x": 12,
-        "y": 13
+        "y": 15
       },
-      "id": 8,
+      "id": 5,
       "options": {
-        "barRadius": 0,
-        "barWidth": 0.97,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
         "orientation": "auto",
-        "showValue": "auto",
-        "stacking": "none",
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 0
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "11.5.4",
       "targets": [
@@ -664,21 +606,93 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "process_resident_memory_bytes",
+          "expr": "min(ndt_min_rtt_ms)",
           "instant": false,
-          "legendFormat": "Memory Usage",
+          "legendFormat": "Min RTT",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "NDT Exporter Memory Usage",
-      "type": "barchart"
+      "title": "Min RTT",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Servers that returned a successful test in the last cycle.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 15
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ndt_server_up)",
+          "instant": false,
+          "legendFormat": "Servers up",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Servers Reporting",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-server download, the multi-location view.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -698,7 +712,6 @@
             "hideFrom": {
               "legend": false,
               "tooltip": false,
-              "vis": false,
               "viz": false
             },
             "insertNulls": false,
@@ -725,10 +738,198 @@
               {
                 "color": "green",
                 "value": null
-              },
+              }
+            ]
+          },
+          "unit": "Mbits"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "ndt_download_mbps",
+          "instant": false,
+          "legendFormat": "{{city}} ({{machine}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Download by Server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-server minimum round-trip time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "color": "red",
-                "value": 80
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "ndt_min_rtt_ms",
+          "instant": false,
+          "legendFormat": "{{city}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Min RTT by Server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Exporter process internals.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -740,7 +941,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 27
       },
       "id": 9,
       "options": {
@@ -764,9 +965,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(python_gc_collections_total[5m])",
+          "expr": "rate(process_cpu_seconds_total[5m]) * 100",
           "instant": false,
-          "legendFormat": "GC Generation {{generation}}",
+          "legendFormat": "CPU Usage %",
           "range": true,
           "refId": "A"
         },
@@ -776,9 +977,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(process_cpu_seconds_total[5m]) * 100",
+          "expr": "process_resident_memory_bytes / 1024 / 1024",
           "instant": false,
-          "legendFormat": "CPU Usage %",
+          "legendFormat": "Memory MB",
           "range": true,
           "refId": "B"
         },
@@ -790,7 +991,7 @@
           "editorMode": "code",
           "expr": "process_open_fds",
           "instant": false,
-          "legendFormat": "Open File Descriptors",
+          "legendFormat": "Open FDs",
           "range": true,
           "refId": "C"
         }
@@ -831,6 +1032,6 @@
   "timezone": "",
   "title": "NDT Internet Speed Test Dashboard",
   "uid": "ndt-speedtest",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/files/ndt-speedtest-exporter/exporter.py
+++ b/files/ndt-speedtest-exporter/exporter.py
@@ -45,6 +45,10 @@ g_rtt = Gauge("ndt_min_rtt_ms", "NDT7 minimum round-trip time (ms)", LABELS)
 g_last_success = Gauge("ndt_last_success_timestamp_seconds", "Unix time of last fully successful cycle")
 g_cycle_seconds = Gauge("ndt_cycle_duration_seconds", "Wall-clock seconds for the last full test cycle")
 g_up = Gauge("ndt_server_up", "1 if the last test against this server succeeded", LABELS)
+# HTTP status of the last M-Lab Locate request: 200 ok, 429 rate-limited, 0
+# non-HTTP error. Stays populated even when we can't run tests, so a dashboard
+# panel shows exactly when the 429s stop.
+g_locate_status = Gauge("ndt_locate_http_status", "HTTP status of the last M-Lab Locate request (200 ok, 429 rate-limited, 0 error)")
 
 
 def locate_servers():
@@ -66,10 +70,12 @@ def cached_servers():
         return _locate["servers"]  # reuse cache; or backing off -> stale/empty
     try:
         servers = locate_servers()
+        g_locate_status.set(200)
         if servers:
             _locate.update(servers=servers, at=now, fails=0, cooldown_until=0.0)
         return _locate["servers"]
     except Exception as e:
+        g_locate_status.set(getattr(e, "code", 0))  # HTTPError has .code (e.g. 429); other errors -> 0
         _locate["fails"] += 1
         backoff = min(LOCATE_TTL, 300 * 2 ** (_locate["fails"] - 1))
         _locate["cooldown_until"] = now + backoff


### PR DESCRIPTION
## What
Makes the NDT dashboard actually report, and adds a panel to watch the M-Lab 429s.

## Two bugs fixed
1. **Dead metric name.** Every speed panel queried `ndt_speedtest` (from the retired old exporter). The NDT7 exporter emits `ndt_download_mbps`, `ndt_upload_mbps`, `ndt_min_rtt_ms`, `ndt_server_up` — verified via Prometheus `label/__name__/values` (`ndt_speedtest` returns empty). So the panels showed **No data** independent of the rate-limit. Repointed all panels to the real metrics (aggregated across the 4 servers, plus per-server download + latency views).
2. **No visibility into the rate-limit.** Added `ndt_locate_http_status` to the exporter (200 ok / 429 rate-limited / 0 error) and a timeseries panel graphing it, so the `429 -> 200` transition is visible — you can see exactly when M-Lab stops blocking us. Plus a 'Since Last Successful Test' staleness stat.

## Files
- `files/ndt-speedtest-exporter/exporter.py` — +`g_locate_status` gauge, set in `cached_servers()`.
- `files/grafana-compose/dashboards/NDT_Internet_Speed_Test_Dashboard.json` — panels repointed; status + staleness panels added; `version` 3 -> 4.

## Verified
py_compile; status-gauge logic test (200/429/0); dashboard is valid JSON, unique panel ids, no `ndt_speedtest` left; all PromQL parses `success` against live Prometheus; ansible syntax-check clean.

## Blast radius
ocean only. Two playbooks run: exporter rebuild+restart (ndt_speedtest) and grafana dashboard provision (grafana_compose, which recreates the Grafana containers -> brief bounce). File-provisioned dashboards reload automatically. Speed panels stay empty until M-Lab unblocks Locate; the new status panel works immediately.