### PR TITLE
feat(agentbox): daily ROADMAP.md reconciler against live fleet

### DIFF
--- a/files/agentbox/agentbox-roadmap-reconcile.service.j2
+++ b/files/agentbox/agentbox-roadmap-reconcile.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=agentbox roadmap reconciler (daily; Claude Code premium lane)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User={{ user }}
+Environment=HOME=/home/{{ user }}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-{{ home }}/.config/agentbox/agentbox.env
+WorkingDirectory={{ home }}
+ExecStart=/usr/local/bin/agentbox-roadmap-reconcile.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=agentbox-roadmap

--- a/files/agentbox/agentbox-roadmap-reconcile.timer.j2
+++ b/files/agentbox/agentbox-roadmap-reconcile.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the agentbox roadmap reconciler daily
+
+[Timer]
+OnCalendar=*-*-* 08:00:00
+RandomizedDelaySec=600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/files/agentbox/roadmap-reconcile.sh
+++ b/files/agentbox/roadmap-reconcile.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# agentbox roadmap reconciler (premium lane).
+# Rendered from files/agentbox/roadmap-reconcile.sh by
+# playbooks/individual/agentbox/agentbox.yaml.
+#
+# Daily: reconcile bluefishforsale/homelab ROADMAP.md against real fleet state.
+# Moves Todo items that are actually DEPLOYED (a matching playbook exists) AND
+# HEALTHY (scrape target up==1, not named by a DOWN target or firing alert) into
+# Completed, and appends live work that is not listed. Never adds speculative
+# future items. Claude Code does the fuzzy matching on the Pro/Max subscription
+# (ANTHROPIC_API_KEY stays unset); the evidence is gathered here and passed in.
+# Result lands as ONE rolling PR a human merges -- homelab is infra, never
+# auto-merged (ADR 0001).
+set -euo pipefail
+unset ANTHROPIC_API_KEY
+
+OWNER="bluefishforsale"
+REPO="homelab"
+SLUG="$OWNER/$REPO"
+BRANCH="agent/roadmap-sync"
+WORKROOT="{{ home }}/work"
+LOGDIR="{{ home }}/agent-logs"
+WT="$WORKROOT/$REPO"
+EV="$LOGDIR/roadmap-evidence.txt"   # outside the worktree: never committed
+PROM="${HOMELAB_PROM:-http://192.168.1.143:9090}"
+ALERT="${HOMELAB_ALERTMANAGER:-http://192.168.1.143:9093}"
+
+# shellcheck disable=SC1091
+source "{{ home }}/.config/agentbox/agentbox.env"
+unset ANTHROPIC_API_KEY  # enforce: subscription auth, not metered API
+mkdir -p "$WORKROOT" "$LOGDIR"
+export OTEL_RESOURCE_ATTRIBUTES="repo=$REPO,lane=claude,service=agentbox"
+
+# Rolling agent branch, always rebased on latest master (like renovate). No human
+# commits land here, so the daily force-push is safe and keeps a single clean PR.
+[ -d "$WT/.git" ] || gh repo clone "$SLUG" "$WT" -- -q
+git -C "$WT" fetch -q origin
+git -C "$WT" checkout -q -B "$BRANCH" origin/HEAD
+
+# --- Evidence: what is deployed AND healthy right now ---
+{
+  echo "# Fleet reality (gathered $(date -u +%FT%TZ))"
+  echo
+  echo "## Healthy Prometheus scrape targets (up==1), count by job:"
+  curl -s -m 10 -G --data-urlencode 'query=count by (job) (up==1)' "$PROM/api/v1/query" \
+    | jq -r '.data.result[]? | "  - \(.metric.job): \(.value[1]) up"' 2>/dev/null | sort || echo "  (Prometheus unreachable)"
+  echo
+  echo "## DOWN targets (up==0) -- treat these as NOT healthy:"
+  curl -s -m 10 -G --data-urlencode 'query=up==0' "$PROM/api/v1/query" \
+    | jq -r '.data.result[]? | "  - \(.metric.job) @ \(.metric.instance)"' 2>/dev/null | sort || true
+  echo
+  echo "## Firing alerts -- a service named here is NOT healthy:"
+  curl -s -m 10 "$ALERT/api/v2/alerts?active=true&silenced=false&inhibited=false" \
+    | jq -r '.[]? | "  - \(.labels.alertname) [\(.labels.severity // "?")] \(.labels.job // .labels.service // "")"' 2>/dev/null | sort -u || echo "  (Alertmanager unreachable)"
+  echo
+  echo "## Deployed services (ansible playbooks in the repo):"
+  ( cd "$WT" && git ls-files 'playbooks/individual/*' | grep -E '\.ya?ml$' | sed -E 's#playbooks/individual/##; s#\.ya?ml$##' | sort -u ) || true
+} > "$EV"
+
+# --- Reconcile with Claude Code (premium lane, headless) ---
+prompt="Reconcile ./ROADMAP.md for the $SLUG homelab repo against the fleet evidence below. Read ./ROADMAP.md first.
+
+Make ONLY these surgical edits with the Edit tool:
+1. If an item under a '## Todo' heading (or a 'Todo'/'In Progress' row in the Vision table) is shown by the evidence to be DEPLOYED (a matching playbook exists) AND HEALTHY (its target is up==1 and it is not named by a DOWN target or firing alert), move that single line into the best-matching subsection under '## Completed' (or flip its Vision-table Status to 'Done'). Only for items the evidence clearly justifies.
+2. Append services that are clearly live in the evidence but appear NOWHERE in ROADMAP.md as bullets under the best-fitting '## Completed' subsection.
+
+Hard rules:
+- NEVER add, invent, reword, or speculate about any Todo / future / planned item. If an item lacks evidence, leave it untouched in Todo.
+- Do NOT reorder, reformat, or edit any line you are not explicitly moving or adding. Keep the diff minimal and surgical.
+- Base every change strictly on the evidence. When unsure, change nothing.
+
+Evidence:
+$(cat "$EV")"
+
+/usr/local/bin/agentbox-trust-dir.sh "$WT" || true
+( cd "$WT" && claude -p "$prompt" --permission-mode acceptEdits ) \
+  >"$LOGDIR/roadmap-reconcile.log" 2>&1 || true
+
+# --- Open/refresh the single rolling PR only if the roadmap actually changed ---
+if [ -z "$(git -C "$WT" status --porcelain ROADMAP.md)" ]; then
+  echo "roadmap already in sync; nothing to do"
+  exit 0
+fi
+git -C "$WT" add ROADMAP.md
+git -C "$WT" commit -q -m "docs(roadmap): reconcile against live fleet state"
+git -C "$WT" push -q -f -u origin "$BRANCH"
+if ! gh pr view "$BRANCH" --repo "$SLUG" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+  gh pr create --repo "$SLUG" --base master --head "$BRANCH" \
+    --title "docs(roadmap): daily reconcile against live fleet" \
+    --body "Automated daily reconcile by agentbox. Todo items now deployed+healthy were moved to Completed and live-but-unlisted work was added, strictly from Prometheus/Alertmanager + playbook evidence. No future or speculative items were added. Review the diff and merge (homelab is infra: a human merges, ADR 0001)." || true
+fi

--- a/playbooks/individual/agentbox/agentbox.yaml
+++ b/playbooks/individual/agentbox/agentbox.yaml
@@ -257,6 +257,7 @@
     loop:
       - { src: issue-watcher.sh, dest: agentbox-issue-watcher.sh }
       - { src: escalate-to-claude.sh, dest: agentbox-escalate-to-claude.sh }
+      - { src: roadmap-reconcile.sh, dest: agentbox-roadmap-reconcile.sh }
       - { src: trust-dir.sh, dest: agentbox-trust-dir.sh }
       - { src: rc-launch.sh, dest: agentbox-rc-launch.sh }
       - { src: alert-receiver.py, dest: agentbox-alert-receiver.py }
@@ -272,6 +273,8 @@
       - agentbox-issue-watcher.timer
       - agentbox-escalate.service
       - agentbox-escalate.timer
+      - agentbox-roadmap-reconcile.service
+      - agentbox-roadmap-reconcile.timer
       - agentbox-alert-receiver.service
       - "agentbox-rc@.service"
     notify: Reload systemd daemon
@@ -288,6 +291,7 @@
     loop:
       - agentbox-issue-watcher.timer
       - agentbox-escalate.timer
+      - agentbox-roadmap-reconcile.timer
 
   - name: Enable and start the alert receiver
     ansible.builtin.systemd:


### PR DESCRIPTION
## What
A daily agentbox systemd timer that keeps `ROADMAP.md` honest: marks Todo items that are actually deployed + healthy as done, and adds work we've shipped but never listed. Never speculates about future projects.

## How
- `files/agentbox/roadmap-reconcile.sh` gathers evidence (Prometheus `up==1`/`up==0`, Alertmanager firing alerts, the repo's `playbooks/individual` inventory), then runs Claude Code headless (`claude -p ... --permission-mode acceptEdits`, Pro/Max subscription, `ANTHROPIC_API_KEY` unset) to make surgical edits: Todo -> Completed for deployed+healthy items, append live-but-unlisted services. Hard rule in the prompt: never add/invent/reword a future item.
- `agentbox-roadmap-reconcile.{service,timer}.j2` — oneshot + daily timer (08:00, jittered).
- Wired into `agentbox.yaml` alongside issue-watcher/escalate.

## Autonomy (ADR 0001)
Lands as **one rolling PR a human merges** — homelab is infra, never auto-merged. Uses a stable `agent/roadmap-sync` branch rebased on master daily (renovate-style force-push; agent-only branch, no human commits at risk). A roadmap `.md` change does not trigger main-apply.

## Verified
shellcheck clean, `bash -n` clean, no stray Jinja (only `{{ home }}`), ansible syntax-check clean. Mirrors the proven `escalate-to-claude.sh` headless-claude pattern.

## Note
Consumes ~1 Claude subscription call/day (shared weekly cap with issue-watcher/escalate).