### PR TITLE
feat(cloudflare): per-URL breakdown + zone dropdown

### DIFF
--- a/files/grafana-compose/dashboards/Cloudflare_terrac.json
+++ b/files/grafana-compose/dashboards/Cloudflare_terrac.json
@@ -7,25 +7,25 @@
   "panels": [
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Requests across all zones in the latest 1h analytics bucket.",
+      "description": "Requests across the selected zones in the latest 1h analytics bucket.",
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]}, "unit": "short"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
       "id": 1,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_requests_1h)", "legendFormat": "Requests", "range": true, "refId": "A"}],
-      "title": "Requests (1h, all zones)",
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_requests_1h{zone=~\"$zone\"})", "legendFormat": "Requests", "range": true, "refId": "A"}],
+      "title": "Requests (1h)",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Cached requests / total requests, all zones.",
+      "description": "Cached requests / total requests, selected zones.",
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "max": 1, "min": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.2}, {"color": "green", "value": 0.5}]}, "unit": "percentunit"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
       "id": 2,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_cached_requests_1h) / clamp_min(sum(cloudflare_zone_requests_1h), 1)", "legendFormat": "Cache hit ratio", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_cached_requests_1h{zone=~\"$zone\"}) / clamp_min(sum(cloudflare_zone_requests_1h{zone=~\"$zone\"}), 1)", "legendFormat": "Cache hit ratio", "range": true, "refId": "A"}],
       "title": "Cache Hit Ratio (1h)",
       "type": "stat"
     },
@@ -37,31 +37,31 @@
       "id": 3,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_threats_1h)", "legendFormat": "Threats", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_threats_1h{zone=~\"$zone\"})", "legendFormat": "Threats", "range": true, "refId": "A"}],
       "title": "Threats (1h)",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Unique visitors across all zones, latest 1h bucket.",
+      "description": "Unique visitors across selected zones, latest 1h bucket.",
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]}, "unit": "short"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
       "id": 4,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_uniques_1h)", "legendFormat": "Uniques", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_uniques_1h{zone=~\"$zone\"})", "legendFormat": "Uniques", "range": true, "refId": "A"}],
       "title": "Unique Visitors (1h)",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Requests per zone over time (latest 1h bucket, sampled each scrape).",
+      "description": "Requests per zone over time.",
       "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}}, "mappings": [], "unit": "short"}, "overrides": []},
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
       "id": 5,
       "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_requests_1h", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_requests_1h{zone=~\"$zone\"}", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
       "title": "Requests by Zone",
       "type": "timeseries"
     },
@@ -73,63 +73,103 @@
       "id": 6,
       "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_bytes_1h", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_bytes_1h{zone=~\"$zone\"}", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
       "title": "Bandwidth by Zone",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Requests by edge response status across all zones.",
+      "description": "Requests by edge response status across selected zones.",
       "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 30, "gradientMode": "none", "lineInterpolation": "stepAfter", "lineWidth": 1, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "normal"}}, "mappings": [], "unit": "short"}, "overrides": []},
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
       "id": 7,
       "options": {"legend": {"calcs": ["max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (status) (cloudflare_zone_requests_by_status_1h)", "legendFormat": "{{status}}", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (status) (cloudflare_zone_requests_by_status_1h{zone=~\"$zone\"})", "legendFormat": "{{status}}", "range": true, "refId": "A"}],
       "title": "Requests by HTTP Status",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Requests by client country (latest 1h bucket), all zones.",
+      "description": "Requests by client country (latest 1h bucket), selected zones.",
       "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"fillOpacity": 70, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineWidth": 1}, "mappings": [], "unit": "short"}, "overrides": []},
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
       "id": 8,
       "options": {"barRadius": 0, "barWidth": 0.8, "fullHighlight": false, "groupWidth": 0.7, "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false}, "orientation": "horizontal", "showValue": "auto", "stacking": "none", "tooltip": {"mode": "single", "sort": "none"}, "xTickLabelRotation": 0, "xTickLabelSpacing": 0},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "topk(15, sum by (country) (cloudflare_zone_requests_by_country_1h))", "format": "time_series", "instant": true, "legendFormat": "{{country}}", "range": false, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "topk(15, sum by (country) (cloudflare_zone_requests_by_country_1h{zone=~\"$zone\"}))", "format": "time_series", "instant": true, "legendFormat": "{{country}}", "range": false, "refId": "A"}],
       "title": "Requests by Country (top 15)",
       "type": "barchart"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Top non-static URLs (pages / APIs, not static assets) by hits in the latest window, per selected zone.",
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "Bytes"}, "properties": [{"id": "unit", "value": "bytes"}]}]},
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 20},
+      "id": 12,
+      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true, "sortBy": [{"desc": true, "displayName": "Hits"}]},
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (zone, path) (cloudflare_zone_url_requests{zone=~\"$zone\"})", "format": "table", "instant": true, "legendFormat": "__auto", "range": false, "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (zone, path) (cloudflare_zone_url_bytes{zone=~\"$zone\"})", "format": "table", "instant": true, "legendFormat": "__auto", "range": false, "refId": "B"}
+      ],
+      "title": "Top URLs (non-static)",
+      "transformations": [
+        {"id": "merge", "options": {}},
+        {"id": "organize", "options": {"excludeByName": {"Time": true}, "indexByName": {"zone": 0, "path": 1, "Value #A": 2, "Value #B": 3}, "renameByName": {"zone": "Zone", "path": "Path", "Value #A": "Hits", "Value #B": "Bytes"}}},
+        {"id": "sortBy", "options": {"fields": [], "sort": [{"desc": true, "field": "Hits"}]}}
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Static assets (css/js/images/fonts/media/etc.) by hits and total bytes served, per selected zone.",
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"}, "overrides": [{"matcher": {"id": "byName", "options": "Bytes"}, "properties": [{"id": "unit", "value": "bytes"}]}]},
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 20},
+      "id": 13,
+      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": ["Hits", "Bytes"], "reducer": ["sum"], "show": true}, "showHeader": true, "sortBy": [{"desc": true, "displayName": "Bytes"}]},
+      "pluginVersion": "11.5.4",
+      "targets": [
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (zone, path) (cloudflare_zone_static_requests{zone=~\"$zone\"})", "format": "table", "instant": true, "legendFormat": "__auto", "range": false, "refId": "A"},
+        {"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum by (zone, path) (cloudflare_zone_static_bytes{zone=~\"$zone\"})", "format": "table", "instant": true, "legendFormat": "__auto", "range": false, "refId": "B"}
+      ],
+      "title": "Static Assets (hits + bytes)",
+      "transformations": [
+        {"id": "merge", "options": {}},
+        {"id": "organize", "options": {"excludeByName": {"Time": true}, "indexByName": {"zone": 0, "path": 1, "Value #A": 2, "Value #B": 3}, "renameByName": {"zone": "Zone", "path": "Path", "Value #A": "Hits", "Value #B": "Bytes"}}},
+        {"id": "sortBy", "options": {"fields": [], "sort": [{"desc": true, "field": "Bytes"}]}}
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "description": "Unique visitors per zone.",
       "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}}, "mappings": [], "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 20},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 30},
       "id": 9,
       "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_uniques_1h", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "cloudflare_zone_uniques_1h{zone=~\"$zone\"}", "legendFormat": "{{zone}}", "range": true, "refId": "A"}],
       "title": "Unique Visitors by Zone",
       "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
       "description": "Zones reporting successfully in the last poll.",
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 3}]}, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 20},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 30},
       "id": 10,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
-      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_up)", "legendFormat": "Zones up", "range": true, "refId": "A"}],
+      "targets": [{"datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "editorMode": "code", "expr": "sum(cloudflare_zone_up{zone=~\"$zone\"})", "legendFormat": "Zones up", "range": true, "refId": "A"}],
       "title": "Zones Reporting",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
-      "description": "Age of the last fully successful exporter poll. Grows if the Cloudflare API or token fails.",
+      "description": "Age of the last fully successful exporter poll (exporter-wide).",
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 900}, {"color": "red", "value": 1800}]}, "unit": "s"}, "overrides": []},
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 20},
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 30},
       "id": 11,
       "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
       "pluginVersion": "11.5.4",
@@ -142,12 +182,15 @@
   "refresh": "5m",
   "schemaVersion": 40,
   "tags": ["cloudflare", "network", "monitoring"],
-  "templating": {"list": [{"current": {"text": "prometheus", "value": "bf02tpxiz6m0wf"}, "name": "DS_PROMETHEUS", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "type": "datasource"}]},
+  "templating": {"list": [
+    {"current": {"text": "prometheus", "value": "bf02tpxiz6m0wf"}, "name": "DS_PROMETHEUS", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "type": "datasource"},
+    {"allValue": ".*", "current": {"text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"}, "definition": "label_values(cloudflare_zone_up, zone)", "includeAll": true, "multi": true, "name": "zone", "options": [], "query": {"query": "label_values(cloudflare_zone_up, zone)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 2, "regex": "", "sort": 1, "type": "query"}
+  ]},
   "time": {"from": "now-24h", "to": "now"},
   "timepicker": {},
   "timezone": "",
   "title": "Cloudflare Analytics (terrac)",
   "uid": "cloudflare-terrac",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/files/ocean-cloudflare-exporter/exporter.py
+++ b/files/ocean-cloudflare-exporter/exporter.py
@@ -34,6 +34,24 @@ for entry in os.environ.get("CF_ZONES", "").split(","):
     ZONES.append((tag.strip(), (name.strip() or tag.strip())))
 POLL_SECONDS = int(os.environ.get("CF_POLL_SECONDS", "300"))
 PORT = int(os.environ.get("CF_PORT", "8080"))
+# Per-URL breakdown (httpRequestsAdaptiveGroups; path dimension works on Free/Pro,
+# contentType does not, so static vs dynamic is classified by URL extension).
+URL_WINDOW = int(os.environ.get("CF_URL_WINDOW_SECONDS", "3600"))
+URL_TOP_N = int(os.environ.get("CF_URL_TOP_N", "10"))       # top non-static URLs per zone
+STATIC_TOP_N = int(os.environ.get("CF_STATIC_TOP_N", "20"))  # top static assets per zone
+STATIC_EXT = {
+    "css", "js", "mjs", "map", "png", "jpg", "jpeg", "gif", "svg", "ico", "webp",
+    "avif", "bmp", "woff", "woff2", "ttf", "eot", "otf", "mp4", "webm", "mov",
+    "mp3", "wav", "ogg", "pdf", "zip", "gz",
+}
+
+
+def is_static(path):
+    """Static asset iff the last path segment has an extension in STATIC_EXT.
+    Pages, .html, .php, /api/*, and extensionless paths are NOT static."""
+    seg = path.split("?", 1)[0].rsplit("/", 1)[-1]
+    ext = seg.rsplit(".", 1)[-1].lower() if "." in seg else ""
+    return ext in STATIC_EXT
 
 g_requests = Gauge("cloudflare_zone_requests_1h", "Requests in the latest 1h bucket", ["zone"])
 g_bytes = Gauge("cloudflare_zone_bytes_1h", "Bytes served in the latest 1h bucket", ["zone"])
@@ -44,6 +62,10 @@ g_uniques = Gauge("cloudflare_zone_uniques_1h", "Unique visitors in the latest 1
 g_by_status = Gauge("cloudflare_zone_requests_by_status_1h", "Requests by edge response status, latest 1h bucket", ["zone", "status"])
 g_by_country = Gauge("cloudflare_zone_requests_by_country_1h", "Requests by client country, latest 1h bucket", ["zone", "country"])
 g_up = Gauge("cloudflare_zone_up", "1 if the last analytics query for this zone succeeded", ["zone"])
+g_url_requests = Gauge("cloudflare_zone_url_requests", "Requests for a top non-static URL (latest window)", ["zone", "path"])
+g_url_bytes = Gauge("cloudflare_zone_url_bytes", "Edge bytes for a top non-static URL (latest window)", ["zone", "path"])
+g_static_requests = Gauge("cloudflare_zone_static_requests", "Requests for a top static-asset URL (latest window)", ["zone", "path"])
+g_static_bytes = Gauge("cloudflare_zone_static_bytes", "Edge bytes for a top static-asset URL (latest window)", ["zone", "path"])
 g_last_success = Gauge("cloudflare_exporter_last_success_timestamp_seconds", "Unix time of the last fully successful poll cycle")
 
 QUERY = """
@@ -55,6 +77,37 @@ query($z:String!,$s:Time!,$u:Time!){viewer{zones(filter:{zoneTag:$z}){
    countryMap{clientCountryName requests}}
   uniq{uniques}}}}}
 """
+
+
+URL_QUERY = """
+query($z:String!,$s:Time!,$u:Time!){viewer{zones(filter:{zoneTag:$z}){
+ httpRequestsAdaptiveGroups(limit:250,filter:{datetime_geq:$s,datetime_leq:$u},orderBy:[count_DESC]){
+  count dimensions{clientRequestPath} sum{edgeResponseBytes}}}}}
+"""
+
+
+def _graphql(query, variables):
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(GRAPHQL_URL, data=body, method="POST", headers={
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+    })
+    with urllib.request.urlopen(req, timeout=20) as r:
+        payload = json.load(r)
+    if payload.get("errors"):
+        raise RuntimeError(payload["errors"])
+    return payload["data"]["viewer"]["zones"][0]
+
+
+def query_urls(tag):
+    now = time.time()
+    zone = _graphql(URL_QUERY, {
+        "z": tag,
+        "s": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - URL_WINDOW)),
+        "u": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+    })
+    return [{"path": g["dimensions"]["clientRequestPath"], "count": g["count"],
+             "bytes": g["sum"]["edgeResponseBytes"]} for g in zone["httpRequestsAdaptiveGroups"]]
 
 
 def query_zone(tag):
@@ -85,6 +138,10 @@ def poll():
     # would wipe the previous zone's series); every zone re-adds its rows below.
     g_by_status.clear()
     g_by_country.clear()
+    g_url_requests.clear()
+    g_url_bytes.clear()
+    g_static_requests.clear()
+    g_static_bytes.clear()
     for tag, name in ZONES:
         try:
             g = query_zone(tag)
@@ -109,6 +166,21 @@ def poll():
             g_up.labels(zone=name).set(0)
             all_ok = False
             print(f"[err] zone {name} ({tag}): {e}", flush=True)
+            continue
+        # Per-URL breakdown is best-effort: a failure here must not fail the zone
+        # or blank its base metrics above.
+        try:
+            rows = query_urls(tag)
+            static = sorted((r for r in rows if is_static(r["path"])), key=lambda r: r["count"], reverse=True)
+            dynamic = sorted((r for r in rows if not is_static(r["path"])), key=lambda r: r["count"], reverse=True)
+            for r in dynamic[:URL_TOP_N]:
+                g_url_requests.labels(zone=name, path=r["path"]).set(r["count"])
+                g_url_bytes.labels(zone=name, path=r["path"]).set(r["bytes"])
+            for r in static[:STATIC_TOP_N]:
+                g_static_requests.labels(zone=name, path=r["path"]).set(r["count"])
+                g_static_bytes.labels(zone=name, path=r["path"]).set(r["bytes"])
+        except Exception as e:
+            print(f"[err] zone {name} urls: {e}", flush=True)
     if all_ok:
         g_last_success.set(time.time())
 


### PR DESCRIPTION
Follow-up to #222. Adds the per-URL tables and zone selector you asked for.

## Exporter
- New query on `httpRequestsAdaptiveGroups` (clientRequestPath + count + edgeResponseBytes) — verified working on Free AND Pro zones (the `contentType` field is Free-gated, so static vs non-static is classified by **URL extension**, which is the cleaner definition anyway).
- Static-asset extensions: css/js/mjs/map/png/jpg/jpeg/gif/svg/ico/webp/avif/bmp/woff/woff2/ttf/eot/otf/mp4/webm/mov/mp3/wav/ogg/pdf/zip/gz. Pages/.html/.php/api/extensionless = non-static.
- New bounded metrics (top-N per zone, `clear()`'d each cycle so stale URLs drop): `cloudflare_zone_url_requests`/`_url_bytes` (top 10 non-static), `cloudflare_zone_static_requests`/`_static_bytes` (top 20 static).
- Verified live: correct classification (`.php`/`/` → non-static; `.js`/`.css`/`.ico`/`.png` → static), 21 dynamic + 26 static series across 3 zones, no errors.

## Dashboard
- **Zone dropdown**: multi-select template variable, defaults to **All**; every existing panel scoped to `{zone=~"$zone"}`.
- **Table: Top URLs (non-static)** — Zone / Path / Hits / Bytes, top 10 per zone.
- **Table: Static Assets** — Zone / Path / Hits / total Bytes (rendered human-readable via Grafana bytes unit), top 20 per zone, with a summed footer.

## Verified
py_compile; built + ran the extended image against the live token (metrics + classification correct); dashboard metrics cross-checked against exporter gauges (13/13); zone var present; ansible syntax-check; no em dashes.

## Note
Table hits/bytes are joined in Grafana via merge on `sum by (zone,path)` (strips `__name__` so the two metrics merge cleanly). Underlying queries verified; I'll confirm the rendered join post-deploy.

## Blast radius
ocean: exporter image rebuild+restart, grafana dashboard reprovision (brief bounce).