### PR TITLE
fix(grafana-backup): retry accessibility check while Grafana boots

### DIFF
--- a/playbooks/operations/backup/grafana_dashboards.yaml
+++ b/playbooks/operations/backup/grafana_dashboards.yaml
@@ -32,6 +32,14 @@
       method: GET
       status_code: 200
     delegate_to: localhost
+    register: grafana_health
+    # This backup runs right after grafana_compose recreates the Grafana
+    # containers (any dashboard-file change triggers both), so /api/health can
+    # be connection-refused for ~60s while Grafana boots. Retry instead of
+    # failing the whole deploy.
+    until: grafana_health.status == 200
+    retries: 20
+    delay: 5
     tags: [verify, execute]
 
   - name: Get list of all dashboards from Grafana API


### PR DESCRIPTION
## Problem
The #224 deploy went red: `Apply Playbooks to Production: failure`. The functional change deployed fine (`cloudflare_exporter.yaml` ✅, `grafana_compose.yaml` ✅ — R2 metrics live, dashboard v3 loaded, verified). The failure was `playbooks/operations/backup/grafana_dashboards.yaml` at 'Verify Grafana is accessible': `Connection refused`.

## Cause
Any dashboard-file change triggers BOTH grafana_compose (which recreates the Grafana containers, ~60s boot) AND this backup playbook, which runs immediately after and health-checks Grafana with **no retry** — a race it loses when Grafana is still booting. It won the race on #222/#223, lost it on #224.

## Fix
Add `until/retries/delay` (20×5s = up to 100s) to the 'Verify Grafana is accessible' uri task — the exact retry pattern the **next** task in the same file already uses for the same reason.

## Verified
ansible syntax-check; no em dashes. This makes dashboard deploys reliable going forward.