### PR TITLE
feat(wordpress): weekly pull-latest + recreate timer

### DIFF
--- a/files/wordpress/wordpress-update.service.j2
+++ b/files/wordpress/wordpress-update.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Weekly WordPress update (pull latest image + recreate)
+After=wordpress.service docker.service
+Wants=wordpress.service
+
+[Service]
+Type=oneshot
+# wordpress.service already does `down -> pull --quiet -> up -d` on start, so a
+# restart re-pulls wordpress:latest and recreates the containers. Reuse that
+# rather than duplicating the compose commands here.
+ExecStart=/usr/bin/systemctl restart wordpress.service
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=wordpress-update

--- a/files/wordpress/wordpress-update.timer.j2
+++ b/files/wordpress/wordpress-update.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly WordPress image update (keep core patched)
+Requires=wordpress-update.service
+
+[Timer]
+OnCalendar=Sun *-*-* 04:00:00
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
+++ b/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
@@ -187,6 +187,27 @@
       name: wordpress.service
       state: started
 
+  - name: Install weekly WordPress update units (pull latest + recreate)
+    ansible.builtin.template:
+      src: "{{ files }}/{{ item }}.j2"
+      dest: "/etc/systemd/system/{{ item }}"
+      mode: '0644'
+    with_items:
+    - wordpress-update.service
+    - wordpress-update.timer
+    notify:
+    - Reload systemd daemon
+
+  - name: Flush handlers so the units are registered before enabling
+    ansible.builtin.meta: flush_handlers
+
+  - name: Enable and start the weekly WordPress update timer
+    ansible.builtin.systemd:
+      name: wordpress-update.timer
+      enabled: yes
+      state: started
+      daemon_reload: yes
+
   handlers:
   - name: Reload systemd daemon
     ansible.builtin.systemd:


### PR DESCRIPTION
Addresses the last item from the WordPress security review (core update lag).

## What
A weekly systemd timer on ocean that pulls `wordpress:latest` and recreates the WP containers, so core stays patched without manual redeploys.

## How
- `wordpress.service` already runs `down -> pull --quiet -> up -d` on start, so the update is just `systemctl restart wordpress.service`.
- `wordpress-update.service.j2` (oneshot) restarts it; `wordpress-update.timer.j2` fires `OnCalendar=Sun *-*-* 04:00:00`, `RandomizedDelaySec=1800`, `Persistent=true`.
- Wired into `blog_saetnere_com_wp.yaml`. Mirrors the `cadvisor-restart` timer pattern.

## Verified
ansible syntax-check; both units render; systemd-analyze verify clean; no em dashes.

## Blast radius
ocean. Deploy only ADDS the timer (the WP recreate task is gated on config changes, none touched here, so this deploy does not restart WP). The weekly job briefly bounces WP at 04:00 Sunday (down->pull->up); DB data persists on its volume.