### PR TITLE
fix(wordpress): drop hardcoded network subnet (auto-assign)

### DIFF
--- a/files/wordpress/docker-compose.yml.j2
+++ b/files/wordpress/docker-compose.yml.j2
@@ -126,8 +126,9 @@ services:
       - wordpress_internal
 
 networks:
+  # No hardcoded subnet: a hardcoded /16 collided with a stale network from the
+  # old compose project name and left wordpress.service unable to restart for ~2
+  # weeks (crash-loop, "invalid pool request: Pool overlaps"). Let Docker
+  # auto-assign a free subnet instead.
   wordpress_internal:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.26.0.0/16


### PR DESCRIPTION
## Incident (surfaced by the #226 weekly-update timer)
The WP compose hardcoded `subnet: 172.26.0.0/16`. A stale network from the **old compose project name** (`wordpress_wordpress_internal`) held that /16; after the project was renamed to `blog_saetnere_com_wp`, `wordpress.service` could not create its network (`invalid pool request: Pool overlaps`) and **crash-looped ~2 weeks (44k+ restarts)**. The site survived only because the old containers were never torn down — **any reboot would have left WordPress down**.

## Fix
Remove the hardcoded subnet; let Docker auto-assign a free subnet (every other service hardcodes its own 172.2x/16, which is what caused the collision).

## Already fixed live
I removed the stale network + old-project containers and recreated WP cleanly on an auto-assigned subnet: container now project=`blog_saetnere_com_wp`, `health=healthy`, `blog.saetnere.com` HTTP 200; `down->pull->up` also re-pulled `wordpress:latest`. `systemctl --failed` = 0, SystemdUnitFailed alert cleared. Outage was ~10s. This PR **codifies** that so IaC matches the running state.

## Deploy note
The compose now differs from the last-rendered on-disk file (added a why-comment), so this deploy will do ONE clean WP recreate (brief blip, succeeds now that the root cause is gone) — which also validates the fix through the pipeline. Subsequent deploys are no-ops.

## Verified
template parses; ansible syntax-check; no em dashes.