### PR TITLE
harden(wordpress): XML-RPC kill + Cloudflare edge WAF/rate-limit (blog.saetnere.com)

### DIFF
--- a/files/wordpress/mu-plugins/harden.php
+++ b/files/wordpress/mu-plugins/harden.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Homelab XML-RPC hardening
+ * Description: Neuters the XML-RPC attack surface (auth brute-force amplification + pingback reflection).
+ *
+ * Lives in mu-plugins so it auto-loads at the right point in the request (add_filter is
+ * not available yet in wp-config.php / WORDPRESS_CONFIG_EXTRA) and survives image updates
+ * because wp-content is the persistent host volume.
+ */
+
+// Disable XML-RPC methods that require authentication -> kills system.multicall brute-force amplification.
+add_filter('xmlrpc_enabled', '__return_false');
+
+// Strip pingback methods (no auth required, used for reflective DDoS and enumeration).
+add_filter('xmlrpc_methods', function ($methods) {
+    unset($methods['pingback.ping'], $methods['pingback.extensions.getPingbacks']);
+    return $methods;
+});
+
+// Stop advertising the endpoint.
+add_filter('wp_headers', function ($headers) {
+    unset($headers['X-Pingback']);
+    return $headers;
+});

--- a/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
+++ b/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
@@ -94,6 +94,24 @@
       mode: '0755'
       recurse: yes
 
+  # mu-plugins auto-load with no activation and survive image updates (wp-content is the
+  # persistent volume). Used here to disable the XML-RPC attack surface at the app layer.
+  - name: Ensure mu-plugins directory exists
+    ansible.builtin.file:
+      path: "{{ home }}/wp-content/mu-plugins"
+      state: directory
+      owner: "33"
+      group: "33"
+      mode: '0755'
+
+  - name: Install WordPress hardening mu-plugin
+    ansible.builtin.copy:
+      src: "{{ files }}/mu-plugins/harden.php"
+      dest: "{{ home }}/wp-content/mu-plugins/harden.php"
+      owner: "33"
+      group: "33"
+      mode: '0644'
+
   - name: Create MySQL configuration from template
     ansible.builtin.template:
       src: "{{ files }}/mysql-custom.cnf.j2"

--- a/scripts/cloudflare-waf.py
+++ b/scripts/cloudflare-waf.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Apply Cloudflare edge hardening (WAF custom rules + rate limiting) to a zone.
+
+Idempotent: each phase entrypoint is fetched, our rules (tagged "homelab:") are
+replaced, any other rules are preserved, then the ruleset is PUT back. Safe to
+re-run.
+
+Creds come from the ansible vault at runtime (nothing secret is committed).
+Run from the repo root on the dev laptop (needs ~/.ansible_vault_pass):
+
+    scripts/cloudflare-waf.py [zone_key]   # zone_key defaults to saetnere_com
+
+Free plan allows 5 custom WAF rules and 1 rate-limiting rule per zone, which is
+what this stays within.
+"""
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+TAG = "homelab:"  # marks rules this script owns, so re-runs replace instead of duplicate
+API = "https://api.cloudflare.com/client/v4"
+
+# WAF custom rules (phase http_request_firewall_custom). Blocks the whole XML-RPC
+# surface at the edge; the mu-plugin is the origin-side belt-and-suspenders.
+CUSTOM_RULES = [
+    {
+        "action": "block",
+        "expression": '(http.request.uri.path eq "/xmlrpc.php")',
+        "description": TAG + "block xmlrpc",
+    },
+]
+
+# One rate-limiting rule (phase http_ratelimit): throttle wp-login brute force.
+# 5 requests / 10s per IP -> block 60s. A human login is 1-2 requests.
+RATELIMIT_RULES = [
+    {
+        "action": "block",
+        "expression": '(http.request.uri.path eq "/wp-login.php")',
+        "description": TAG + "rate-limit wp-login",
+        "ratelimit": {
+            "characteristics": ["ip.src", "cf.colo.id"],
+            "period": 10,
+            "requests_per_period": 5,
+            "mitigation_timeout": 60,
+        },
+    },
+]
+
+
+def vault():
+    passfile = os.path.expanduser("~/.ansible_vault_pass")
+    here = os.path.dirname(os.path.abspath(__file__))
+    secrets = os.path.join(here, "..", "vault", "secrets.yaml")
+    out = subprocess.check_output(
+        ["ansible-vault", "view", "--vault-password-file", passfile, secrets]
+    )
+    return yaml.safe_load(out)
+
+
+def api(method, path, headers, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(API + path, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        sys.exit(f"{method} {path} -> {e.code}\n{e.read().decode()}")
+
+
+def apply_phase(headers, zone, phase, rules):
+    ep = api("GET", f"/zones/{zone}/rulesets/phases/{phase}/entrypoint", headers)
+    existing = ep.get("result", {}).get("rules") or []
+    kept = [r for r in existing if not (r.get("description") or "").startswith(TAG)]
+    merged = kept + rules
+    api(
+        "PUT",
+        f"/zones/{zone}/rulesets/phases/{phase}/entrypoint",
+        headers,
+        {"rules": merged},
+    )
+    print(f"  {phase}: {len(kept)} preserved + {len(rules)} homelab = {len(merged)} rules")
+
+
+def main():
+    zone_key = sys.argv[1] if len(sys.argv) > 1 else "saetnere_com"
+    cf = vault()["cloudflare"]
+    zone = cf[zone_key]
+    headers = {
+        "X-Auth-Email": cf["api_email"],
+        "X-Auth-Key": cf["api_key"],
+        "Content-Type": "application/json",
+    }
+    print(f"zone {zone_key} ({zone}):")
+    apply_phase(headers, zone, "http_request_firewall_custom", CUSTOM_RULES)
+    apply_phase(headers, zone, "http_ratelimit", RATELIMIT_RULES)
+    print("done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes the top-two remaining WordPress security risks for **blog.saetnere.com**.

## App layer (ships via this deploy)
- `files/wordpress/mu-plugins/harden.php` — mu-plugin (auto-loads, no activation, survives image updates via the persistent `wp-content` volume):
  - `xmlrpc_enabled => false` — disables authenticated XML-RPC, killing `system.multicall` brute-force amplification.
  - strips `pingback.ping` / `pingback.extensions.getPingbacks` — kills pingback reflective-DDoS + enumeration.
  - removes the `X-Pingback` header so the endpoint isn't advertised.
- Playbook installs it into `wp-content/mu-plugins/` owned by www-data (33).

## Edge layer (external Cloudflare account, applied out-of-band)
- `scripts/cloudflare-waf.py` — idempotent (GET-merge-PUT, preserves non-`homelab:` rules), reads creds from the vault at runtime, no secret committed. Applies to the saetnere.com zone:
  - WAF custom rule: block `/xmlrpc.php` at the edge (belt-and-suspenders + covers LAN-origin bypass).
  - one rate-limit rule: `/wp-login.php` at 5 req/10s per IP -> block 60s (the real remaining brute-force surface once XML-RPC amplification is dead).
- Not part of the ansible apply; run manually from the dev laptop. Free plan allows 5 custom WAF rules + 1 rate-limit rule, which this stays within.

**Host/service touched:** ocean / `wordpress.service` (blog.saetnere.com). No container recreate — the mu-plugin loads live.