### PR TITLE
fix(homepage): drop the /app/.next bind mount (fixes 22k-restart crash-loop)

### DIFF
--- a/files/gethomepage/docker-compose.yml.j2
+++ b/files/gethomepage/docker-compose.yml.j2
@@ -19,7 +19,6 @@ services:
     volumes:
       - {{ home }}/config:/app/config
       - {{ home }}/images:/app/public/images
-      - {{ home }}/.next:/app/.next
       - /data01:/data01:ro
 
     healthcheck:


### PR DESCRIPTION
The `gethomepage/homepage:latest` image (Next.js standalone) ships its compiled build at `/app/.next`. The compose bind-mounted an empty host dir there, shadowing the build, so the container crash-looped on "Could not find a production build" (22k+ restarts, status=restarting). `config` and `images` are the real persistent volumes; `.next` is app-internal and should never have been mounted. Removing it lets the container use the baked-in build.

**Host/service:** ocean / homepage dashboard. Container recreate on deploy.