### PR TITLE
fix(wordpress): disable loopback wp-cron + hourly digest-aware image refresh

### DIFF
--- a/files/wordpress/docker-compose.yml.j2
+++ b/files/wordpress/docker-compose.yml.j2
@@ -22,6 +22,7 @@ services:
           define('WP_SITEURL', 'https://{{ cloud_services.wordpress.domain }}');
           define('FORCE_SSL_ADMIN', true);
           define('FORCE_SSL_LOGIN', true);
+          define('DISABLE_WP_CRON', true);
           if (isset($$_SERVER['HTTP_X_FORWARDED_PROTO']) && $$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
             $$_SERVER['HTTPS'] = 'on';
           }

--- a/files/wordpress/wordpress-cron.service.j2
+++ b/files/wordpress/wordpress-cron.service.j2
@@ -8,7 +8,14 @@ Type=oneshot
 # WP loopback cron is disabled (DISABLE_WP_CRON) because the http self-request was
 # being 301'd at the Cloudflare edge and never executing. Run wp-cron.php directly
 # inside the container instead: no HTTP, no redirect, no external dependency.
-ExecStart=/usr/bin/docker exec {{ service }} php /var/www/html/wp-cron.php
+# Guard on the container being up so a tick during a recreate (deploy / hourly image
+# refresh) is a clean no-op, not a terminal-failed unit that trips SystemdUnitFailed.
+ExecStart=/bin/bash -c '\
+  if docker inspect -f "{% raw %}{{.State.Running}}{% endraw %}" {{ service }} 2>/dev/null | grep -q true; then \
+    docker exec {{ service }} php /var/www/html/wp-cron.php; \
+  else \
+    echo "{{ service }} not running, skipping cron tick"; \
+  fi'
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=wordpress-cron

--- a/files/wordpress/wordpress-cron.service.j2
+++ b/files/wordpress/wordpress-cron.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=WordPress scheduled tasks (wp-cron, run in-container)
+After=wordpress.service docker.service
+Wants=wordpress.service
+
+[Service]
+Type=oneshot
+# WP loopback cron is disabled (DISABLE_WP_CRON) because the http self-request was
+# being 301'd at the Cloudflare edge and never executing. Run wp-cron.php directly
+# inside the container instead: no HTTP, no redirect, no external dependency.
+ExecStart=/usr/bin/docker exec {{ service }} php /var/www/html/wp-cron.php
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=wordpress-cron

--- a/files/wordpress/wordpress-cron.timer.j2
+++ b/files/wordpress/wordpress-cron.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run WordPress scheduled tasks every 5 minutes
+Requires=wordpress-cron.service
+
+[Timer]
+OnCalendar=*:0/5
+# No Persistent: a missed 5-minute tick across a reboot is not worth a catch-up burst.
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target

--- a/files/wordpress/wordpress-update.service.j2
+++ b/files/wordpress/wordpress-update.service.j2
@@ -1,14 +1,24 @@
 [Unit]
-Description=Weekly WordPress update (pull latest image + recreate)
+Description=WordPress image refresh (pull latest, recreate only if changed)
 After=wordpress.service docker.service
 Wants=wordpress.service
 
 [Service]
 Type=oneshot
-# wordpress.service already does `down -> pull --quiet -> up -d` on start, so a
-# restart re-pulls wordpress:latest and recreates the containers. Reuse that
-# rather than duplicating the compose commands here.
-ExecStart=/usr/bin/systemctl restart wordpress.service
+# Pull wordpress:latest and recreate ONLY when the digest actually moved, so this
+# can run frequently to stay fresh without a gratuitous ~10s outage every tick.
+# wordpress.service start does `down -> pull --quiet -> up -d`, so a restart applies
+# the just-pulled image.
+ExecStart=/bin/bash -c '\
+  docker pull -q {{ image }}:{{ version }} >/dev/null; \
+  running=$(docker inspect --format "{% raw %}{{.Image}}{% endraw %}" {{ service }} 2>/dev/null || echo none); \
+  latest=$(docker image inspect --format "{% raw %}{{.Id}}{% endraw %}" {{ image }}:{{ version }}); \
+  if [ "$running" != "$latest" ]; then \
+    echo "wordpress image changed ($running -> $latest), recreating"; \
+    systemctl restart wordpress.service; \
+  else \
+    echo "wordpress image unchanged, skipping recreate"; \
+  fi'
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=wordpress-update

--- a/files/wordpress/wordpress-update.timer.j2
+++ b/files/wordpress/wordpress-update.timer.j2
@@ -1,11 +1,13 @@
 [Unit]
-Description=Weekly WordPress image update (keep core patched)
+Description=Hourly WordPress image refresh (stay on latest core)
 Requires=wordpress-update.service
 
 [Timer]
-OnCalendar=Sun *-*-* 04:00:00
-RandomizedDelaySec=1800
-Persistent=true
+OnCalendar=hourly
+# No Persistent: the service is digest-aware, but a catch-up burst on deploy/boot
+# could recreate the container right after the deploy already did. Skip a missed
+# tick; the next hour catches it.
+RandomizedDelaySec=300
 
 [Install]
 WantedBy=timers.target

--- a/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
+++ b/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
@@ -205,7 +205,7 @@
       name: wordpress.service
       state: started
 
-  - name: Install weekly WordPress update units (pull latest + recreate)
+  - name: Install WordPress update + cron units
     ansible.builtin.template:
       src: "{{ files }}/{{ item }}.j2"
       dest: "/etc/systemd/system/{{ item }}"
@@ -213,18 +213,23 @@
     with_items:
     - wordpress-update.service
     - wordpress-update.timer
+    - wordpress-cron.service
+    - wordpress-cron.timer
     notify:
     - Reload systemd daemon
 
   - name: Flush handlers so the units are registered before enabling
     ansible.builtin.meta: flush_handlers
 
-  - name: Enable and start the weekly WordPress update timer
+  - name: Enable and start the WordPress update + cron timers
     ansible.builtin.systemd:
-      name: wordpress-update.timer
+      name: "{{ item }}"
       enabled: yes
       state: started
       daemon_reload: yes
+    with_items:
+    - wordpress-update.timer
+    - wordpress-cron.timer
 
   handlers:
   - name: Reload systemd daemon


### PR DESCRIPTION
## Why
The wp-cron loopback (WordPress self-requesting `/wp-cron.php`) was being `301`'d at the Cloudflare edge (Always Use HTTPS) and never executing, so scheduled tasks (update checks, scheduled posts, transient cleanup) silently stopped. Diagnosed from the exporter: ~27 req/hr, all `301`, 1 unique, 0 threats, top URL `/wp-cron.php`; origin log showed zero non-localhost hits.

## Change
- **Disable loopback cron**: `define('DISABLE_WP_CRON', true)` in compose CONFIG_EXTRA.
- **Run cron directly**: `wordpress-cron.{service,timer}` runs `docker exec ... php /var/www/html/wp-cron.php` every 5 min. No HTTP, no redirect. Guarded on the container being up so a tick mid-recreate is a no-op (no `SystemdUnitFailed` noise).
- **Fresher core**: `wordpress-update.service` is now digest-aware (pull `wordpress:latest`, recreate only if the image ID moved) and the timer runs **hourly** instead of weekly - stays on latest without a recreate every tick.

## Host/service
ocean / `wordpress.service` (blog.saetnere.com). Compose change recreates the WP container on deploy (~10s).