### PR TITLE
add(scripts): homelab admin query helpers (prom / systemd / loki)

### DIFF
--- a/scripts/fleet-systemctl.sh
+++ b/scripts/fleet-systemctl.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# fleet-systemctl.sh — systemd status across the homelab fleet over SSH.
+#
+# Hosts come from the ansible inventory (inventories/production/hosts.ini), so this
+# tracks the real fleet. Each host is reached as ansible_user@ansible_ssh_host (the
+# inventory is authoritative; SSH host aliases/users are not).
+#
+# Usage:
+#   fleet-systemctl.sh all                     one line per host: failed count + running count
+#   fleet-systemctl.sh list [host]             list active service units (all hosts, or one)
+#   fleet-systemctl.sh <service> [host]        status of a unit across the fleet (or one host)
+#   fleet-systemctl.sh host <host>             detail for one host: failed units + timers
+#
+# <service> may omit the .service suffix. Exit 1 if any targeted host has a failed unit
+# (so it is usable as a check).
+#
+# Env: HOMELAB_INVENTORY (default inventories/production/hosts.ini),
+#      SSH_TIMEOUT (default 5), FLEET_HOSTS (space-separated override of the host list)
+set -uo pipefail
+
+INV="${HOMELAB_INVENTORY:-$(dirname "$0")/../inventories/production/hosts.ini}"
+SSH_TIMEOUT="${SSH_TIMEOUT:-5}"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# Emit "name<TAB>user@ip" per inventory host with an ansible_ssh_host, deduped.
+hosts() {
+  if [ -n "${FLEET_HOSTS:-}" ]; then
+    # FLEET_HOSTS is names only; resolve each against the inventory.
+    for h in $FLEET_HOSTS; do _inventory | awk -v n="$h" '$1==n'; done
+    return
+  fi
+  _inventory
+}
+_inventory() {
+  [ -f "$INV" ] || die "inventory not found: $INV"
+  awk '
+    /^[[:space:]]*#/ { next }               # skip commented-out host lines
+    /ansible_ssh_host=/ {
+      name=$1; user=""; ip=""
+      for (i=1;i<=NF;i++) {
+        if ($i ~ /^ansible_user=/)      { split($i,a,"="); user=a[2] }
+        if ($i ~ /^ansible_ssh_host=/)  { split($i,a,"="); ip=a[2] }
+      }
+      if (ip != "" && !(name in seen)) { seen[name]=1; printf "%s\t%s@%s\n", name, user, ip }
+    }' "$INV"
+}
+
+# Run a command on a host; prints nothing on connect failure but returns 1.
+# Hard-bounded by `timeout` so a host that accepts the TCP connect but then hangs
+# (auth stall, wedged sshd) can't stall the whole fleet sweep — SSH's own timeouts
+# don't cover every hang.
+on_host() {
+  local dest=$1; shift
+  # -n: read stdin from /dev/null so ssh can't swallow the caller's `while read` host list.
+  timeout "$((SSH_TIMEOUT * 3))" \
+    ssh -n -o ConnectTimeout="$SSH_TIMEOUT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    "$dest" "$@" 2>/dev/null
+}
+
+cmd_all() {
+  local rc=0
+  while IFS=$'\t' read -r name dest; do
+    local out failed running
+    out=$(on_host "$dest" 'echo "$(systemctl list-units --type=service --state=failed --no-legend --plain 2>/dev/null | wc -l) $(systemctl list-units --type=service --state=running --no-legend --plain 2>/dev/null | wc -l)"') \
+      || { printf '%-18s UNREACHABLE\n' "$name"; rc=1; continue; }
+    failed=${out%% *}; running=${out##* }
+    if [ "${failed:-0}" -gt 0 ]; then
+      printf '%-18s %s failed, %s running\n' "$name" "$failed" "$running"
+      on_host "$dest" 'systemctl list-units --type=service --state=failed --no-legend --plain' \
+        | awk '{print "    ✗ "$1}'
+      rc=1
+    else
+      printf '%-18s ok (%s running)\n' "$name" "$running"
+    fi
+  done < <(hosts)
+  return $rc
+}
+
+cmd_list() {
+  local only=${1:-}
+  while IFS=$'\t' read -r name dest; do
+    [ -n "$only" ] && [ "$name" != "$only" ] && continue
+    printf '── %s ──\n' "$name"
+    on_host "$dest" 'systemctl list-units --type=service --state=active --no-legend --plain' \
+      | awk '{printf "  %-40s %s %s\n", $1, $3, $4}' || echo "  UNREACHABLE"
+  done < <(hosts)
+}
+
+cmd_service() {
+  local svc=$1 only=${2:-} rc=0 found=0
+  case "$svc" in *.*) ;; *) svc="$svc.service" ;; esac
+  while IFS=$'\t' read -r name dest; do
+    [ -n "$only" ] && [ "$name" != "$only" ] && continue
+    local state
+    state=$(on_host "$dest" "systemctl show '$svc' -p LoadState,ActiveState,SubState,ActiveEnterTimestamp --value 2>/dev/null | paste -sd'|' -") || { continue; }
+    # LoadState|ActiveState|SubState|Since
+    local load active sub since
+    IFS='|' read -r load active sub since <<<"$state"
+    [ "$load" = "not-found" ] || [ -z "$load" ] && continue
+    found=1
+    printf '%-18s %-10s %-10s since %s\n' "$name" "$active" "$sub" "${since:-?}"
+    [ "$active" = "failed" ] && rc=1
+  done < <(hosts)
+  [ "$found" -eq 0 ] && die "no host has a unit named $svc"
+  return $rc
+}
+
+cmd_host() {
+  local only=${1:?usage: fleet-systemctl.sh host <host>}
+  local dest
+  dest=$(hosts | awk -v n="$only" '$1==n {print $2}')
+  [ -n "$dest" ] || die "host not in inventory: $only"
+  printf '── %s (%s) ──\n' "$only" "$dest"
+  echo "[failed units]"
+  on_host "$dest" 'systemctl list-units --type=service --state=failed --no-legend --plain' \
+    | awk 'NF{print "  ✗ "$1" "$3" "$4} END{if(NR==0)print "  (none)"}' || die "unreachable: $only"
+  echo "[timers — next runs]"
+  on_host "$dest" 'systemctl list-timers --no-legend --no-pager 2>/dev/null | head -12' \
+    | awk 'NF{printf "  %s %s → %s\n", $1, $2, $NF}'
+}
+
+[ $# -ge 1 ] || usage 1
+case "$1" in
+  all)  cmd_all ;;
+  list) cmd_list "${2:-}" ;;
+  host) cmd_host "${2:-}" ;;
+  -h|--help|help) usage 0 ;;
+  *)    cmd_service "$1" "${2:-}" ;;
+esac

--- a/scripts/loki.sh
+++ b/scripts/loki.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# loki.sh — pull logs for a service on a host from the homelab Loki.
+#
+# A "service" is matched as a docker container name first, then falls back to a
+# systemd unit — so it works whether the thing runs in compose (container=) or as a
+# unit (unit=). Force one with -c/--container or -u/--unit.
+#
+# Usage:
+#   loki.sh <service> <host> [since] [limit] [match]
+#     since   time window back from now (30m, 2h, 1d, or seconds). default 1h
+#     limit   max lines. default 300
+#     match   optional substring line-filter (LogQL |= "…")
+#   loki.sh -u <unit> <host> [since] [limit] [match]      force systemd unit
+#   loki.sh -c <container> <host> [since] [limit] [match]  force docker container
+#
+# Examples:
+#   loki.sh blog_saetnere_com_wp ocean 2h
+#   loki.sh -u wordpress ocean 1d 500 error
+#
+# Env: HOMELAB_LOKI (default http://192.168.1.143:3100), HOMELAB_LOKI_TIMEOUT (default 8)
+set -uo pipefail
+
+LOKI="${HOMELAB_LOKI:-http://192.168.1.143:3100}"
+TIMEOUT="${HOMELAB_LOKI_TIMEOUT:-8}"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+label=""            # forced label (container|unit), empty = auto
+case "${1:-}" in
+  -h|--help|help) usage 0 ;;
+  -c|--container) label="container"; shift ;;
+  -u|--unit)      label="unit";      shift ;;
+esac
+
+svc="${1:-}"; host="${2:-}"
+[ -n "$svc" ] && [ -n "$host" ] || usage 1
+since="${3:-1h}"; limit="${4:-300}"; match="${5:-}"
+
+# duration -> seconds (s/m/h/d suffix, or bare seconds)
+dur_s() {
+  case "$1" in
+    *s) echo "${1%s}" ;;
+    *m) echo "$(( ${1%m} * 60 ))" ;;
+    *h) echo "$(( ${1%h} * 3600 ))" ;;
+    *d) echo "$(( ${1%d} * 86400 ))" ;;
+    *)  echo "$1" ;;
+  esac
+}
+now=$(date +%s)
+start_ns=$(( (now - $(dur_s "$since")) * 1000000000 ))
+end_ns=$(( now * 1000000000 ))
+
+# Fetch for a given label; echoes raw JSON. Returns nonzero on transport error.
+fetch() {
+  local sel="{host=\"$host\", $1=~\"^$svc.*\"}"
+  [ -n "$match" ] && sel="$sel |= \"$match\""
+  curl -fsS -m "$TIMEOUT" -G "$LOKI/loki/api/v1/query_range" \
+    --data-urlencode "query=$sel" \
+    --data-urlencode "start=$start_ns" --data-urlencode "end=$end_ns" \
+    --data-urlencode "limit=$limit" --data-urlencode "direction=backward" 2>/dev/null
+}
+
+# Count streams in a Loki response.
+streams() { printf '%s' "$1" | jq -r '.data.result | length' 2>/dev/null; }
+
+resp=""
+if [ -n "$label" ]; then
+  resp=$(fetch "$label") || die "loki: query failed (is $LOKI reachable?)"
+else
+  resp=$(fetch container) || die "loki: query failed (is $LOKI reachable?)"
+  if [ "$(streams "$resp")" = "0" ]; then
+    resp=$(fetch unit) || die "loki: query failed"
+    label="unit"
+  else
+    label="container"
+  fi
+fi
+
+[ "$(streams "$resp")" = "0" ] && die "no logs: no $([ -n "$label" ] && echo "$label" || echo container/unit) matching '$svc' on $host in the last $since"
+
+# Flatten all streams' [ts_ns, line] pairs, sort ascending by time, print "MM-DD HH:MM:SS  line".
+printf '%s' "$resp" | jq -r '
+  [ .data.result[] | .values[] ] | sort_by(.[0])
+  | .[] | "\((.[0]|tonumber/1e9|strflocaltime("%m-%d %H:%M:%S")))  \(.[1])"'

--- a/scripts/prom.sh
+++ b/scripts/prom.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# prom.sh — thin Prometheus query helper for the homelab.
+#
+# Stops every ad-hoc `curl .../api/v1/query --data-urlencode ... | jq` from being
+# rewritten by hand. Talks to the ocean Prometheus by default; override with
+# HOMELAB_PROM.
+#
+# Usage:
+#   prom.sh q '<promql>'                 instant query -> "value  {labels}" per series, desc
+#   prom.sh raw '<promql>'               instant query -> raw JSON (pipe to jq)
+#   prom.sh names [regex]                list metric names (__name__), optional grep filter
+#   prom.sh labels <metric>              show the distinct label sets for a metric
+#   prom.sh targets [up|down]            scrape targets, optionally filtered by health
+#
+# For time ranges, use a range-vector inside an instant query (no range subcommand):
+#   prom.sh q 'max_over_time((rate(foo[5m]))[24h:10m])'
+#
+# Env: HOMELAB_PROM (default http://192.168.1.143:9090), HOMELAB_PROM_TIMEOUT (default 5)
+set -uo pipefail
+
+PROM="${HOMELAB_PROM:-http://192.168.1.143:9090}"
+TIMEOUT="${HOMELAB_PROM_TIMEOUT:-5}"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# raw instant query -> JSON on stdout; nonzero + message on API/transport failure.
+_query() {
+  local out
+  out=$(curl -fsS -m "$TIMEOUT" -G "$PROM/api/v1/query" --data-urlencode "query=$1" 2>/dev/null) \
+    || die "prom: query failed (is $PROM reachable?)"
+  printf '%s' "$out" | jq -e '.status=="success"' >/dev/null 2>&1 \
+    || die "prom: query error: $(printf '%s' "$out" | jq -r '.error // "unknown"')"
+  printf '%s' "$out"
+}
+
+[ $# -ge 1 ] || usage 1
+cmd=$1; shift
+
+case "$cmd" in
+  q)
+    [ $# -ge 1 ] || die "usage: prom.sh q '<promql>'"
+    # "value  {label=val,...}" per series, numeric-desc; __name__ dropped from labels.
+    _query "$1" | jq -r '
+      .data.result[]
+      | (.value[1]) as $v
+      | (.metric | del(.__name__) | to_entries | map("\(.key)=\(.value)") | join(",")) as $l
+      | "\($v)\t{\($l)}"' \
+    | sort -t$'\t' -k1 -gr ;;
+  raw)
+    [ $# -ge 1 ] || die "usage: prom.sh raw '<promql>'"
+    _query "$1" ;;
+  names)
+    out=$(curl -fsS -m "$TIMEOUT" "$PROM/api/v1/label/__name__/values" 2>/dev/null) \
+      || die "prom: names failed"
+    printf '%s' "$out" | jq -r '.data[]' | { [ $# -ge 1 ] && grep -iE "$1" || cat; } ;;
+  labels)
+    [ $# -ge 1 ] || die "usage: prom.sh labels <metric>"
+    _query "$1" | jq -r '.data.result[].metric | del(.__name__) | to_entries
+      | map("\(.key)=\(.value)") | join(",")' | sort -u ;;
+  targets)
+    out=$(curl -fsS -m "$TIMEOUT" "$PROM/api/v1/targets?state=active" 2>/dev/null) \
+      || die "prom: targets failed"
+    printf '%s' "$out" | jq -r --arg f "${1:-}" '
+      .data.activeTargets[]
+      | select($f=="" or .health==$f)
+      | "\(.health)\t\(.labels.job)\t\(.scrapeUrl)"' | sort ;;
+  -h|--help|help) usage 0 ;;
+  *) die "unknown command: $cmd (try: prom.sh --help)" ;;
+esac


### PR DESCRIPTION
Three reusable read-only admin scripts so they stop getting hand-rewritten each session. All laptop tools in `scripts/` (outside the main-apply push filter, so no deploy).

- **prom.sh** — Prometheus query wrapper. `q` (value+labels, desc), `raw`, `names [regex]`, `labels <metric>`, `targets [up|down]`. Env `HOMELAB_PROM`.
- **fleet-systemctl.sh** — systemd status across the fleet: `all` / `list [host]` / `<service> [host]` / `host <host>`. Hosts parsed from `inventories/production/hosts.ini`; reaches each as `ansible_user@ansible_ssh_host` with `ssh -n` hard-bounded by `timeout` (one wedged host can't stall the sweep).
- **loki.sh** — logs for a service on a host. Auto-matches docker `container` then falls back to systemd `unit`; `-c`/`-u` to force; optional line filter. Env `HOMELAB_LOKI`.

Tested live against the fleet: prom `q`/`names`/`targets`, systemctl `all` (9 hosts) / `host ocean` / `wordpress ocean`, loki container+unit+filter.