### PR TITLE
add(scripts): docker / cf / alerts / fleet-restart admin helpers

### DIFF
--- a/scripts/alerts.sh
+++ b/scripts/alerts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# alerts.sh — homelab Alertmanager: active alerts and silences.
+#
+# Usage:
+#   alerts.sh [active]        active alerts (default): severity, name, instance, age
+#   alerts.sh all             include silenced/inhibited
+#   alerts.sh silences        active silences: matcher, who, ends
+#
+# Env: HOMELAB_ALERTMANAGER (default http://192.168.1.143:9093), HOMELAB_AM_TIMEOUT (default 5)
+set -uo pipefail
+
+AM="${HOMELAB_ALERTMANAGER:-http://192.168.1.143:9093}"
+TIMEOUT="${HOMELAB_AM_TIMEOUT:-5}"
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+get() { curl -fsS -m "$TIMEOUT" "$AM$1" 2>/dev/null || die "alertmanager unreachable: $AM"; }
+
+case "${1:-active}" in
+  active|all)
+    filt="?active=true&silenced=false&inhibited=false"
+    [ "${1:-active}" = "all" ] && filt="?active=true&silenced=true&inhibited=true"
+    get "/api/v2/alerts$filt" | jq -r '
+      sort_by(.labels.severity, .labels.alertname)[]
+      | "\(.labels.severity // "-")\t\(.labels.alertname)\t\(.labels.instance // "-")\t\(.status.state)\tsince \(.startsAt)"' \
+    | awk -F'\t' 'BEGIN{n=0}
+        {n++; printf "%-9s %-28s %-24s %-10s %s\n", $1,$2,$3,$4,$5}
+        END{if(n==0)print "no alerts"; else printf "\n%d alert(s)\n", n}' ;;
+  silences)
+    get "/api/v2/silences" | jq -r '
+      [.[] | select(.status.state=="active")] as $a
+      | if ($a|length)==0 then "no active silences"
+        else ($a[] | "\(.matchers|map("\(.name)\(if .isRegex then "=~" else "=" end)\(.value)")|join(","))\tby \(.createdBy)\tends \(.endsAt)")
+        end' | sed 's/\t/  /g' ;;
+  -h|--help|help) usage 0 ;;
+  *) die "unknown command: $1 (try: alerts.sh --help)" ;;
+esac

--- a/scripts/cf.sh
+++ b/scripts/cf.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# cf.sh — Cloudflare zone helper for the homelab (analytics/DNS/cache one-offs).
+#
+# Creds come from the ansible vault at runtime (nothing secret committed). Zone may be a
+# known domain, or a raw 32-hex zone id.
+#
+# Usage:
+#   cf.sh zones                          list known zones + ids
+#   cf.sh cache-status <url>             show cf-cache-status / content-type / HTTP for a URL
+#   cf.sh dns <zone> [name]              list DNS records (optional name substring filter)
+#   cf.sh dns-add <zone> <type> <name> <content> [ttl]   add a DNS record (ttl default 300)
+#   cf.sh purge <zone> [url ...]         purge cache: everything, or just the given URLs
+#
+# Examples:
+#   cf.sh cache-status https://blog.terrac.com/
+#   cf.sh purge terrac.com https://blog.terrac.com/ https://blog.terrac.com/posts/
+#
+# Env: ANSIBLE_VAULT_PASS (default ~/.ansible_vault_pass), CF_TIMEOUT (default 10)
+set -uo pipefail
+
+TIMEOUT="${CF_TIMEOUT:-10}"
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# Known zones (public ids, mirror cf_zones in cloudflare_exporter.yaml).
+declare -A ZONES=(
+  [terrac.com]=f3be74ced16c63d68b522f569ecba43b
+  [saetnere.com]=427cd2f89d3669d1704f61f3d37d4149
+  [radiantatmospheres.com]=87401274f499c81d52527080d0588e7f
+)
+
+zone_id() {
+  local z=$1
+  [ -n "${ZONES[$z]:-}" ] && { echo "${ZONES[$z]}"; return; }
+  [[ "$z" =~ ^[0-9a-f]{32}$ ]] && { echo "$z"; return; }
+  die "unknown zone: $z (known: ${!ZONES[*]}, or a 32-hex id)"
+}
+
+# Emit "email\nkey" from the vault; cached in globals after first call.
+_EMAIL=""; _KEY=""
+creds() {
+  [ -n "$_KEY" ] && return
+  local pass="${ANSIBLE_VAULT_PASS:-$HOME/.ansible_vault_pass}"
+  local secrets; secrets="$(dirname "$0")/../vault/secrets.yaml"
+  local out
+  out=$(python3 - "$pass" "$secrets" <<'PY'
+import sys, subprocess, yaml
+pw, path = sys.argv[1], sys.argv[2]
+raw = subprocess.check_output(["ansible-vault","view","--vault-password-file",pw,path])
+cf = yaml.safe_load(raw)["cloudflare"]
+print(cf["api_email"]); print(cf["api_key"])
+PY
+) || die "could not read cloudflare creds from vault"
+  _EMAIL=$(printf '%s\n' "$out" | sed -n 1p)
+  _KEY=$(printf '%s\n' "$out" | sed -n 2p)
+}
+
+# cf_api METHOD PATH [json-body] -> response JSON; dies on API error.
+cf_api() {
+  creds
+  local method=$1 path=$2 body=${3:-}
+  local args=(-fsS -m "$TIMEOUT" -X "$method"
+    -H "X-Auth-Email: $_EMAIL" -H "X-Auth-Key: $_KEY" -H "Content-Type: application/json")
+  [ -n "$body" ] && args+=(--data "$body")
+  local resp
+  resp=$(curl "${args[@]}" "https://api.cloudflare.com/client/v4$path" 2>/dev/null) \
+    || die "cf api $method $path failed"
+  printf '%s' "$resp" | jq -e '.success' >/dev/null 2>&1 \
+    || die "cf api error: $(printf '%s' "$resp" | jq -c '.errors')"
+  printf '%s' "$resp"
+}
+
+case "${1:-}" in
+  zones)
+    for z in "${!ZONES[@]}"; do printf '%-28s %s\n' "$z" "${ZONES[$z]}"; done | sort ;;
+  cache-status)
+    url=${2:?usage: cf.sh cache-status <url>}
+    curl -s -o /dev/null -D - "$url" \
+      | grep -iE "^HTTP|^cf-cache-status|^content-type|^age|^cache-control" | tr -d '\r' ;;
+  dns)
+    z=$(zone_id "${2:?usage: cf.sh dns <zone> [name]}"); filt=${3:-}
+    cf_api GET "/zones/$z/dns_records?per_page=100" \
+      | jq -r '.result[] | "\(.type)\t\(.name)\t\(.content)\tproxied=\(.proxied)"' \
+      | { [ -n "$filt" ] && grep -i "$filt" || cat; } \
+      | awk -F'\t' '{printf "%-6s %-38s %-40s %s\n", $1,$2,$3,$4}' ;;
+  dns-add)
+    z=$(zone_id "${2:?usage: cf.sh dns-add <zone> <type> <name> <content> [ttl]}")
+    typ=${3:?type}; name=${4:?name}; content=${5:?content}; ttl=${6:-300}
+    body=$(jq -nc --arg t "$typ" --arg n "$name" --arg c "$content" --argjson ttl "$ttl" \
+      '{type:$t,name:$n,content:$c,ttl:$ttl}')
+    cf_api POST "/zones/$z/dns_records" "$body" \
+      | jq -r '"added \(.result.type) \(.result.name) -> \(.result.content) (id \(.result.id))"' ;;
+  purge)
+    z=$(zone_id "${2:?usage: cf.sh purge <zone> [url ...]}"); shift 2
+    if [ $# -eq 0 ]; then
+      echo "purging EVERYTHING for zone $z ..."
+      cf_api POST "/zones/$z/purge_cache" '{"purge_everything":true}' | jq -r '"purged: success=\(.success)"'
+    else
+      body=$(printf '%s\n' "$@" | jq -R . | jq -sc '{files:.}')
+      cf_api POST "/zones/$z/purge_cache" "$body" | jq -r "\"purged $# url(s): success=\(.success)\""
+    fi ;;
+  -h|--help|help|"") usage 0 ;;
+  *) die "unknown command: $1 (try: cf.sh --help)" ;;
+esac

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# docker.sh — Docker container status across the homelab fleet over SSH (read-only).
+#
+# Hosts come from the ansible inventory. Reaches each as ansible_user@ansible_ssh_host.
+#
+# Usage:
+#   docker.sh ps [host]                containers on host(s): name, status, health, restarts
+#   docker.sh where <container>        which host(s) run a container matching the name
+#   docker.sh status <container> [host] detail: state, health, restarts, image, started, mounts
+#   docker.sh logs <container> [host] [n]  tail n log lines (default 60); host auto-found if omitted
+#
+# <container> is a name substring (matches like `docker ps --filter name=`).
+# Env: HOMELAB_INVENTORY, SSH_TIMEOUT (see lib/inventory.sh)
+set -uo pipefail
+. "$(dirname "$0")/lib/inventory.sh"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# Find "name<TAB>user@ip" host rows that actually run a container matching $1.
+_hosts_running() {
+  while IFS=$'\t' read -r name dest; do
+    local hit
+    hit=$(on_host "$dest" "docker ps -a --filter name=$1 --format '{{.Names}}'" ) || continue
+    [ -n "$hit" ] && printf '%s\t%s\t%s\n' "$name" "$dest" "$(printf '%s' "$hit" | paste -sd, -)"
+  done < <(fleet_hosts)
+}
+
+cmd_ps() {
+  local only=${1:-}
+  while IFS=$'\t' read -r name dest; do
+    [ -n "$only" ] && [ "$name" != "$only" ] && continue
+    printf '── %s ──\n' "$name"
+    on_host "$dest" 'docker ps --format "{{.Names}}\t{{.Status}}" 2>/dev/null | sort' \
+      | awk -F'\t' 'NF{printf "  %-32s %s\n", $1, $2} END{if(NR==0)print "  (none / unreachable)"}'
+  done < <(fleet_hosts)
+}
+
+cmd_where() {
+  local c=${1:?usage: docker.sh where <container>} found=0
+  while IFS=$'\t' read -r name dest running; do
+    found=1; printf '%-18s %s\n' "$name" "$running"
+  done < <(_hosts_running "$c")
+  [ "$found" -eq 0 ] && die "no host runs a container matching '$c'"
+}
+
+cmd_status() {
+  local c=${1:?usage: docker.sh status <container> [host]} host=${2:-} dest
+  if [ -n "$host" ]; then dest=$(resolve_host "$host"); [ -n "$dest" ] || die "host not in inventory: $host"
+  else dest=$(_hosts_running "$c" | head -1 | cut -f2); [ -n "$dest" ] || die "no host runs '$c'"; fi
+  # Resolve the exact container name (first match) on that host.
+  local cn
+  cn=$(on_host "$dest" "docker ps -a --filter name=$c --format '{{.Names}}' | head -1")
+  [ -n "$cn" ] || die "no container matching '$c' on that host"
+  echo "container: $cn  (host $host${host:+ }$dest)"
+  on_host "$dest" "docker inspect $cn --format '  state:    {{.State.Status}}{{if .State.Health}} ({{.State.Health.Status}}){{end}}
+  restarts: {{.RestartCount}}
+  image:    {{.Config.Image}}
+  started:  {{.State.StartedAt}}
+  exit:     {{.State.ExitCode}}{{if .State.Error}}  err={{.State.Error}}{{end}}'"
+  echo "  mounts:"
+  on_host "$dest" "docker inspect $cn --format '{{range .Mounts}}    {{.Source}} -> {{.Destination}}{{println}}{{end}}'"
+}
+
+cmd_logs() {
+  local c=${1:?usage: docker.sh logs <container> [host] [n]} host=${2:-} n=${3:-60} dest
+  if [ -n "$host" ]; then dest=$(resolve_host "$host"); [ -n "$dest" ] || die "host not in inventory: $host"
+  else dest=$(_hosts_running "$c" | head -1 | cut -f2); [ -n "$dest" ] || die "no host runs '$c'"; fi
+  local cn
+  cn=$(on_host "$dest" "docker ps -a --filter name=$c --format '{{.Names}}' | head -1")
+  [ -n "$cn" ] || die "no container matching '$c' on that host"
+  on_host "$dest" "docker logs --tail $n $cn 2>&1"
+}
+
+[ $# -ge 1 ] || usage 1
+case "$1" in
+  ps)     cmd_ps "${2:-}" ;;
+  where)  cmd_where "${2:-}" ;;
+  status) cmd_status "${2:-}" "${3:-}" ;;
+  logs)   cmd_logs "${2:-}" "${3:-}" "${4:-}" ;;
+  -h|--help|help) usage 0 ;;
+  *) die "unknown command: $1 (try: docker.sh --help)" ;;
+esac

--- a/scripts/fleet-restart.sh
+++ b/scripts/fleet-restart.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# fleet-restart.sh — restart a systemd unit or docker container on ONE host.
+#
+# The only state-mutating helper in this set, so it is deliberately narrow: an explicit
+# target and host, no wildcards, existence-checked, and a confirmation prompt unless -y.
+#
+# Usage:
+#   fleet-restart.sh restart <unit> <host> [-y]      sudo systemctl restart <unit>
+#   fleet-restart.sh container <name> <host> [-y]    docker restart <container> (in-place bounce)
+#
+# NOTE: homelab systemd units run `compose down -> pull -> up` on start, so
+# `restart <unit>` RECREATES the container (picks up a new image / compose change). Use
+# `container` for a fast in-place bounce that does NOT recreate.
+#
+# Env: HOMELAB_INVENTORY, SSH_TIMEOUT (see lib/inventory.sh)
+set -uo pipefail
+. "$(dirname "$0")/lib/inventory.sh"
+
+die() { printf '%s\n' "$*" >&2; exit 1; }
+usage() { grep -E '^#' "$0" | sed -n '/Usage:/,$p' | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+confirm() {  # $1 = prompt; auto-yes if $YES
+  [ "${YES:-0}" = "1" ] && return 0
+  local ans
+  printf '%s [y/N] ' "$1" >&2
+  read -r ans </dev/tty || return 1
+  [ "$ans" = "y" ] || [ "$ans" = "Y" ]
+}
+
+[ $# -ge 3 ] || usage 1
+mode=$1 target=$2 host=$3
+YES=0; [ "${4:-}" = "-y" ] && YES=1
+dest=$(resolve_host "$host"); [ -n "$dest" ] || die "host not in inventory: $host"
+
+case "$mode" in
+  restart)
+    # Verify the unit exists (LoadState != not-found) before touching it.
+    load=$(on_host "$dest" "systemctl show '$target' -p LoadState --value 2>/dev/null") \
+      || die "unreachable: $host"
+    [ "$load" = "not-found" ] || [ -z "$load" ] && die "no systemd unit '$target' on $host"
+    echo "before: $(on_host "$dest" "systemctl is-active '$target'; systemctl show '$target' -p SubState --value" | paste -sd' ' -)"
+    confirm "restart unit '$target' on $host (recreates the container)?" || die "aborted"
+    on_host "$dest" "sudo -n systemctl restart '$target'" || die "restart failed (passwordless sudo? unit ok?)"
+    sleep 3
+    echo "after:  $(on_host "$dest" "systemctl is-active '$target'; systemctl show '$target' -p SubState --value" | paste -sd' ' -)" ;;
+  container)
+    cn=$(on_host "$dest" "docker ps -a --filter name=$target --format '{{.Names}}' | head -1") \
+      || die "unreachable: $host"
+    [ -n "$cn" ] || die "no container matching '$target' on $host"
+    echo "before: $(on_host "$dest" "docker inspect $cn --format '{{.State.Status}} restarts={{.RestartCount}}'")"
+    confirm "docker restart '$cn' on $host?" || die "aborted"
+    on_host "$dest" "docker restart $cn" >/dev/null || die "docker restart failed"
+    sleep 3
+    echo "after:  $(on_host "$dest" "docker inspect $cn --format '{{.State.Status}}{{if .State.Health}} ({{.State.Health.Status}}){{end}}'")" ;;
+  -h|--help|help) usage 0 ;;
+  *) die "unknown mode: $mode (try: fleet-restart.sh --help)" ;;
+esac

--- a/scripts/lib/inventory.sh
+++ b/scripts/lib/inventory.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# inventory.sh — shared fleet host resolution + bounded SSH for the homelab admin scripts.
+# Source it: . "$(dirname "$0")/lib/inventory.sh"
+#
+# Provides:
+#   fleet_hosts            -> "name<TAB>user@ip" per inventory host (deduped)
+#   resolve_host <name>    -> "user@ip" for one host, empty if unknown
+#   on_host <user@ip> <cmd...>  -> run cmd over ssh, hard-bounded, stdin from /dev/null
+#
+# Env: HOMELAB_INVENTORY (default inventories/production/hosts.ini), SSH_TIMEOUT (default 5)
+
+_INV_DEFAULT="$(dirname "${BASH_SOURCE[0]}")/../../inventories/production/hosts.ini"
+INV="${HOMELAB_INVENTORY:-$_INV_DEFAULT}"
+SSH_TIMEOUT="${SSH_TIMEOUT:-5}"
+
+fleet_hosts() {
+  [ -f "$INV" ] || { printf 'inventory not found: %s\n' "$INV" >&2; return 1; }
+  awk '
+    /^[[:space:]]*#/ { next }                 # skip commented-out host lines
+    /ansible_ssh_host=/ {
+      name=$1; user=""; ip=""
+      for (i=1;i<=NF;i++) {
+        if ($i ~ /^ansible_user=/)     { split($i,a,"="); user=a[2] }
+        if ($i ~ /^ansible_ssh_host=/) { split($i,a,"="); ip=a[2] }
+      }
+      if (ip != "" && !(name in seen)) { seen[name]=1; printf "%s\t%s@%s\n", name, user, ip }
+    }' "$INV"
+}
+
+resolve_host() { fleet_hosts | awk -v n="$1" -F'\t' '$1==n {print $2}'; }
+
+# -n keeps ssh from swallowing a caller's `while read` stdin; timeout bounds a wedged host.
+on_host() {
+  local dest=$1; shift
+  timeout "$((SSH_TIMEOUT * 3))" \
+    ssh -n -o ConnectTimeout="$SSH_TIMEOUT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    "$dest" "$@" 2>/dev/null
+}


### PR DESCRIPTION
Second batch of homelab admin helpers (all in scripts/, outside the deploy filter). Read-only except fleet-restart.

- **lib/inventory.sh** — shared fleet host resolution + bounded ssh -n (factored out; docker.sh and fleet-restart.sh source it).
- **docker.sh** — container status across the fleet: ps [host] / where <c> / status <c> [host] / logs <c> [host] [n].
- **cf.sh** — Cloudflare one-offs: zones / cache-status <url> / dns <zone> [name] / dns-add / purge <zone> [url...]. Vault creds at runtime. Purge pairs with the new 2h edge cache (fresh content else lags).
- **alerts.sh** — Alertmanager active alerts + silences.
- **fleet-restart.sh** — the one mutation: restart <unit> (recreates via compose down/up) or container <name> (in-place bounce) on ONE host. Guarded: explicit target+host, existence-checked, confirm prompt unless -y, passwordless sudo only, before/after state.

Tested live against the fleet: docker where/status, cf zones/cache-status/dns/purge (purge flipped blog.terrac.com to MISS), alerts, restart guardrails + a real plex-exporter bounce.