### PR TITLE
docs: wire admin/diagnostic scripts into agent context

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -38,6 +38,20 @@ Ansible-driven homelab managing Bare metal, VMs, Docker services, GPU passthroug
 - **GitHub Actions Workflows** → [`.github/workflows/`](.github/workflows/)
 - **Playbook Documentation** → [`playbooks/README.md`](playbooks/README.md)
 
+### Diagnostics & Admin Scripts
+
+**Reach for [`scripts/`](scripts/README.md) before hand-rolling `ssh host 'docker …'` or
+`curl prometheus | jq`.** Full index: [`scripts/README.md`](scripts/README.md). The ones you
+want most often:
+
+- **Metrics** → [`scripts/prom.sh`](scripts/prom.sh) `q '<promql>'` / `names` / `targets down`
+- **Logs for a service on a host** → [`scripts/loki.sh`](scripts/loki.sh) `<svc> <host> [since] [limit] [match]`
+- **systemd across the fleet** → [`scripts/fleet-systemctl.sh`](scripts/fleet-systemctl.sh) `all` / `<service> [host]` / `host <host>`
+- **Docker across the fleet** → [`scripts/docker.sh`](scripts/docker.sh) `where <c>` / `status <c> [host]` / `logs`
+- **Active alerts** → [`scripts/alerts.sh`](scripts/alerts.sh)
+- **Cloudflare (DNS / cache-status / purge)** → [`scripts/cf.sh`](scripts/cf.sh) — `purge` after editing a cached static site
+- **Restart/bounce a service on one host** → [`scripts/fleet-restart.sh`](scripts/fleet-restart.sh) (guarded; the only mutating fleet tool)
+
 ---
 
 ## Deploy gotchas (READ before shipping a change)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,50 @@
+# scripts/
+
+Admin, diagnostic, and action helpers for the homelab. **Reach for these before
+hand-rolling `ssh host 'docker ...'` or `curl prometheus | jq`** — they exist so those
+one-offs stop getting rewritten every session.
+
+Everything here runs from the dev laptop (or a checkout on the LAN). The query tools need
+the homelab LAN reachable; the Cloudflare tools need the ansible vault
+(`~/.ansible_vault_pass`). **`scripts/` is outside the `main-apply` push filter — changes
+here never trigger CI or a deploy**, so a scripts-only PR merges with no checks.
+
+## Diagnostics & query (read-only)
+
+| Script | What | Example |
+|---|---|---|
+| `prom.sh` | Prometheus: `q '<promql>'`, `raw`, `names [regex]`, `labels <metric>`, `targets [up\|down]` | `prom.sh q 'up==0'` |
+| `loki.sh` | logs for a service on a host (auto container→unit; `-c`/`-u` to force) | `loki.sh blog_saetnere_com_wp ocean 2h 200 error` |
+| `fleet-systemctl.sh` | systemd across the fleet: `all` / `list [host]` / `<service> [host]` / `host <host>` | `fleet-systemctl.sh all` |
+| `docker.sh` | containers across the fleet: `ps [host]` / `where <c>` / `status <c> [host]` / `logs <c> [host] [n]` | `docker.sh where plex` |
+| `alerts.sh` | Alertmanager: active alerts (default), `all`, `silences` | `alerts.sh` |
+| `exporter-scrape-check.sh` | Prometheus targets that are down + their exporter | `exporter-scrape-check.sh` |
+| `dns-drift-check.sh` | divergence between the two authoritative PowerDNS nodes | `dns-drift-check.sh` |
+| `dns-parity-check.sh` | compare dns01 vs dns02 HA nodes record-by-record | `dns-parity-check.sh` |
+| `homelab-health.sh` | fleet health gate by diff: `snapshot <f>` / `verify <f>` (used by the ship flow) | `homelab-health.sh verify /tmp/base.json` |
+
+## Actions (mutating — used deliberately)
+
+| Script | What | Notes |
+|---|---|---|
+| `fleet-restart.sh` | `restart <unit> <host>` (recreates via compose down/pull/up) or `container <name> <host>` (in-place bounce) | one host, existence-checked, confirm unless `-y`, passwordless `sudo -n` only |
+| `cf.sh` | Cloudflare: `zones` / `cache-status <url>` / `dns <zone> [name]` / `dns-add …` / `purge <zone> [url…]` | vault creds; `purge` pairs with the 2h static edge cache |
+| `cloudflare-harden.py` | per-zone TLS/HSTS + security headers + host-scoped static cache rule | idempotent; classifier may block the live run → run by hand |
+| `cloudflare-waf.py` | per-zone WAF block + rate-limit rules (WordPress zones) | idempotent; run by hand |
+| `media-reclaim-report.py` / `media-reclaim-delete.py` | profile the library / delete via Radarr+Sonarr with unmonitor + import-exclusion | delete is destructive |
+| `media_clients.py` | one client wrapping radarr/sonarr/tdarr/plex/overseerr/tautulli | library used by the media scripts |
+
+## Environment overrides
+
+| Var | Default | Used by |
+|---|---|---|
+| `HOMELAB_PROM` | `http://192.168.1.143:9090` | prom.sh, homelab-health.sh |
+| `HOMELAB_ALERTMANAGER` | `http://192.168.1.143:9093` | alerts.sh, homelab-health.sh |
+| `HOMELAB_LOKI` | `http://192.168.1.143:3100` | loki.sh |
+| `HOMELAB_INVENTORY` | `inventories/production/hosts.ini` | fleet-systemctl.sh, docker.sh, fleet-restart.sh |
+| `SSH_TIMEOUT` | `5` | the ssh-based fleet tools |
+| `~/.ansible_vault_pass` | — | cf.sh, cloudflare-*.py |
+
+The ssh-based tools resolve hosts from the ansible inventory (reached as
+`ansible_user@ansible_ssh_host` — SSH aliases/users are not authoritative) via the shared
+`scripts/lib/inventory.sh` (`fleet_hosts` / `resolve_host` / `on_host`).


### PR DESCRIPTION
Makes the admin script suite discoverable so agents (and future me) reach for them instead of hand-rolling ssh+curl+jq.

- **scripts/README.md** — grouped index of every helper (diagnostics/query, mutating actions, Cloudflare, media) with usage one-liners and the env-var overrides table.
- **agents.md** — new 'Diagnostics & Admin Scripts' section in the Documentation Index highlighting the most-used tools (prom/loki/fleet-systemctl/docker/alerts/cf/fleet-restart) and pointing at the README.

Docs only, root + scripts/ — outside the deploy filter, no CI/deploy.