### PR TITLE
fix(blog): purge Cloudflare edge cache after deploy

### DIFF
--- a/playbooks/individual/ocean/services/blog_terrac_com_static.yaml
+++ b/playbooks/individual/ocean/services/blog_terrac_com_static.yaml
@@ -28,6 +28,9 @@
     uid: 1001
     gid: 1001
     accept_hostkey: yes
+    # Public identifier, not a secret. Canonical list lives in
+    # scripts/cloudflare-harden.py (ZONES) and monitoring/cloudflare_exporter.yaml (cf_zones).
+    cloudflare_zone_id: f3be74ced16c63d68b522f569ecba43b
 
   tasks:
 
@@ -161,6 +164,28 @@
     ansible.builtin.debug:
       msg: "WARNING: index.html not found in {{ web_root }}. The website may not load correctly."
     when: not index_file.stat.exists
+    tags: [deploy]
+
+  # scripts/cloudflare-harden.py pins these hosts to a 2h edge TTL with
+  # mode "override_origin", so Cloudflare ignores any Cache-Control nginx
+  # sends and serves stale HTML for up to 2h after a deploy. Purging by host
+  # is the only thing that shortens that; adding origin headers does nothing.
+  - name: Purge Cloudflare edge cache for blog.terrac.com
+    ansible.builtin.uri:
+      url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/purge_cache"
+      method: POST
+      headers:
+        X-Auth-Email: "{{ cloudflare.api_email }}"
+        X-Auth-Key: "{{ cloudflare.api_key }}"
+      body_format: json
+      body:
+        hosts:
+          - blog.terrac.com
+      status_code: 200
+    delegate_to: localhost
+    become: false
+    no_log: true
+    when: index_file.stat.exists
     tags: [deploy]
 
   - name: Display deployment success


### PR DESCRIPTION
## Problem

`blog.terrac.com` served a homepage up to 2h stale after every deploy. Observed on the live site while the origin was already correct:

```
cf-cache-status: HIT
age: 6652
last-modified: Sat, 01 Aug 2026 19:13:58 GMT   # origin was 12 days newer
```

Three published posts were invisible to anyone hitting the homepage, while their direct URLs returned 200. A cache-buster query showed the correct content immediately, confirming the origin was fine and the edge was not.

## Cause

`scripts/cloudflare-harden.py:141` pins these hosts to:

```python
"edge_ttl": {"mode": "override_origin", "default": CACHE_EDGE_TTL},  # 7200
```

`override_origin` means Cloudflare ignores any `Cache-Control` the origin sends, so adding headers to the nginx block would have done nothing. The script's own comment at `:51` already names the remedy: *"2h at the edge; new content lags up to this until a cache purge."*

The 2h TTL is deliberate protection for the home uplink and is left alone.

## Fix

A host-scoped `purge_cache` call at the end of the blog deploy. Notes:

- `delegate_to: localhost` so the call comes from the runner, not ocean
- `no_log: true` so the API key stays out of CI logs
- `when: index_file.stat.exists` so a failed clone cannot purge a good cache
- creds come from the vault the playbook already loads (`vars_files`)
- zone id is a public identifier, already committed in two other places

## Verification

`ansible-playbook --syntax-check` passes. The API call was run by hand against the live zone first:

```
before   cf-cache-status: HIT    age: 6652
purge    success: True | errors: []
after    cf-cache-status: MISS   last-modified: Fri, 14 Aug 2026 06:20:05 GMT
```

The homepage then listed all seven published posts with no cache-buster.

Not auto-merging: this touches deploy infra, so leaving the merge to a human.