### PR TITLE
feat(wordpress): route mail through the exim hub (fix sendmail: not found)

### DIFF
--- a/files/wordpress/docker-compose.yml.j2
+++ b/files/wordpress/docker-compose.yml.j2
@@ -23,6 +23,7 @@ services:
           define('FORCE_SSL_ADMIN', true);
           define('FORCE_SSL_LOGIN', true);
           define('DISABLE_WP_CRON', true);
+          define('WP_SMTP_HOST', '{{ ansible_default_ipv4.address }}');
           if (isset($$_SERVER['HTTP_X_FORWARDED_PROTO']) && $$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
             $$_SERVER['HTTPS'] = 'on';
           }
@@ -36,7 +37,7 @@ services:
       - PHP_MAX_EXECUTION_TIME=300
       # Timezone Configuration
       - TZ=America/Los_Angeles
-    
+
     ports:
       - "{{ port_ext }}:{{ port_int }}"
     

--- a/files/wordpress/mu-plugins/smtp.php
+++ b/files/wordpress/mu-plugins/smtp.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin Name: Homelab SMTP relay
+ * Description: Route WordPress mail through the ocean exim smarthost hub (-> Brevo), so
+ *   password resets / notifications actually send. The container has no sendmail; PHP
+ *   mail() fails ("sendmail: not found") without this.
+ *
+ * mu-plugin so it auto-loads and survives image updates (wp-content is the persistent
+ * volume). The hub does TLS to Brevo; the WP->hub hop is plaintext on the trusted LAN.
+ */
+
+add_action('phpmailer_init', function ($phpmailer) {
+    // WP_SMTP_HOST is defined in wp-config via WORDPRESS_CONFIG_EXTRA (reliable under
+    // Apache, unlike getenv); default to the docker gateway (= the ocean host).
+    $host = defined('WP_SMTP_HOST') ? WP_SMTP_HOST : '172.26.0.1';
+    $phpmailer->isSMTP();
+    $phpmailer->Host       = $host;
+    $phpmailer->Port       = 25;
+    $phpmailer->SMTPAuth   = false;      // hub trusts the LAN relay_nets; no auth on this hop
+    $phpmailer->SMTPSecure = '';         // no TLS to the hub (self-signed); hub->Brevo is TLS
+    $phpmailer->SMTPAutoTLS = false;     // don't opportunistically STARTTLS to the self-signed hub
+});
+
+// From must be on the Brevo-authenticated domain (saetnere.com) so DKIM aligns.
+add_filter('wp_mail_from', function ($from) {
+    return (strpos($from, '@saetnere.com') !== false) ? $from : 'wordpress@saetnere.com';
+});
+add_filter('wp_mail_from_name', function ($name) {
+    return $name ?: 'blog.saetnere.com';
+});

--- a/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
+++ b/playbooks/individual/ocean/services/blog_saetnere_com_wp.yaml
@@ -112,6 +112,14 @@
       group: "33"
       mode: '0644'
 
+  - name: Install WordPress SMTP-relay mu-plugin
+    ansible.builtin.copy:
+      src: "{{ files }}/mu-plugins/smtp.php"
+      dest: "{{ home }}/wp-content/mu-plugins/smtp.php"
+      owner: "33"
+      group: "33"
+      mode: '0644'
+
   - name: Create MySQL configuration from template
     ansible.builtin.template:
       src: "{{ files }}/mysql-custom.cnf.j2"


### PR DESCRIPTION
WordPress (blog.saetnere.com) had no sendmail in the image, so password-reset / notification mail silently failed. This routes PHPMailer through the ocean exim smarthost hub via an mu-plugin.

- `mu-plugins/smtp.php`: PHPMailer → hub (`WP_SMTP_HOST`, defined in wp-config via CONFIG_EXTRA), port 25, no auth (trusted-LAN relay_net), no TLS on the WP→hub hop (hub→Brevo is TLS). Forces From to @saetnere.com so DKIM aligns.
- saetnere.com is now authenticated in Brevo (free tier allows the 2nd domain; DKIM published via cf.sh).

Host/service: ocean / blog_saetnere_com_wp (recreate to pick up the config define).