### PR TITLE
feat(alerting): email alerts via the exim hub (alongside ntfy)

### DIFF
--- a/files/ocean-prometheus/alertmanager.yml.j2
+++ b/files/ocean-prometheus/alertmanager.yml.j2
@@ -1,7 +1,9 @@
 global:
-  # Global configuration options
-  smtp_smarthost: 'localhost:587'
-  smtp_from: 'alertmanager@{{ ansible_default_ipv4.address }}'
+  # Global configuration options — relay through the ocean exim smarthost hub (-> Brevo,
+  # signed as terrac.com). Plaintext on the trusted LAN hop; the hub does TLS to Brevo.
+  smtp_smarthost: '{{ ansible_default_ipv4.address }}:25'
+  smtp_from: 'alertmanager@terrac.com'
+  smtp_require_tls: false
 
 # The directory from which notification templates are read.
 templates: []
@@ -39,6 +41,10 @@ receivers:
 - name: 'agentbox'
   webhook_configs:
   - url: 'http://agentbox.home:9098/'
+    send_resolved: true
+  # Email alongside the ntfy/GitHub fan-out, via the exim hub (as terrac.com).
+  email_configs:
+  - to: 'terracnosaur@gmail.com'
     send_resolved: true
 
 # Example email receiver (commented out)


### PR DESCRIPTION
Adds email to Alertmanager, routed through the ocean exim hub (signed as terrac.com), without disturbing the existing ntfy/GitHub fan-out.

- Global SMTP: `smtp_smarthost` was a dead `localhost:587` → now the hub (`<ocean-ip>:25`), `smtp_from: alertmanager@terrac.com`, `smtp_require_tls: false` (LAN hop; hub→Brevo is TLS).
- Added `email_configs` (to terracnosaur@gmail.com, send_resolved) to the existing `agentbox` receiver, so every alert also emails.

Host/service: ocean / prometheus-alertmanager. Deploy recreates alertmanager to reload config.