### PR TITLE
feat(photonic): schedule the weekly chase-up digest

### DIFF
--- a/playbooks/individual/ocean/services/photonic_inventory.yaml
+++ b/playbooks/individual/ocean/services/photonic_inventory.yaml
@@ -105,6 +105,20 @@
       name: photonic_inventory.service
       state: restarted
 
+  # Weekly chase-up digest: gear past its return date and still out, bookings
+  # waiting on an owner to approve, and returns with something missing or in
+  # repair. Sends only to BOOTSTRAP_ADMIN_EMAIL, and sends nothing on a quiet
+  # week. Monday 08:10 local, after the container is certain to be up.
+  - name: Schedule photonic_inventory weekly digest
+    ansible.builtin.cron:
+      name: "photonic_inventory weekly digest"
+      weekday: "1"
+      hour: "8"
+      minute: "10"
+      job: "/usr/bin/docker exec photonic_inventory python -m app.digest_cli >/dev/null 2>&1"
+      user: root
+      state: present
+
   handlers:
   - name: Reload systemd daemon
     ansible.builtin.systemd:


### PR DESCRIPTION
The one piece of photonic_inventory's digest that lives in this repo. App side shipped in [photonic_inventory#10](https://github.com/bluefishforsale/photonic_inventory/pull/10).

Weekly cron on ocean, Monday 08:10:
```
/usr/bin/docker exec photonic_inventory python -m app.digest_cli
```

It reports gear past its return date and still out, bookings waiting on an owner to approve, and returns with something still missing or in repair. Sends **only** to `BOOTSTRAP_ADMIN_EMAIL` (verified as terracnosaur@gmail.com on ocean) and sends **nothing** on a quiet week, so it doesn't become noise.

Verified: `ansible-playbook --syntax-check` passes with the vault key, and `--dry-run` against prod correctly found the overdue booking and two pending approvals.

Not merging this myself — it's fleet infra and the deploy is yours to trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192FDdPxQdMZWcZKzsXCcH7