### PR TITLE
docs(roadmap): daily reconcile against live fleet

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,6 +41,7 @@ Status and future plans for the homelab infrastructure.
 - **Registry cache**: Pull-through Docker registry cache VM
 - **NFS server**: NFS exports for shared storage
 - **AFP**: Apple Filing Protocol file sharing
+- **Agentbox**: Autonomous agent fleet VM (OpenTelemetry collector telemetry)
 
 ### Media Stack
 
@@ -78,6 +79,7 @@ Status and future plans for the homelab infrastructure.
 - **NDT Speedtest**: Network diagnostic speedtest monitoring
 - **Cloudflare Exporter**: Cloudflare metrics exporter for Prometheus
 - **ntfy**: Push notification service
+- **cAdvisor**: Per-container resource metrics exporter
 
 ### Cloud/CMS Services
 


### PR DESCRIPTION
Automated daily reconcile by agentbox. Todo items now deployed+healthy were moved to Completed and live-but-unlisted work was added, strictly from Prometheus/Alertmanager + playbook evidence. No future or speculative items were added. Review the diff and merge (homelab is infra: a human merges, ADR 0001).