### PR TITLE
fix(tdarr): clone private plugins repo over SSH, not anonymous HTTPS

### DIFF
--- a/playbooks/individual/ocean/media/tdarr.yaml
+++ b/playbooks/individual/ocean/media/tdarr.yaml
@@ -22,7 +22,11 @@
     path_home: "{{ path_data01 }}/{{ service }}"
     transcode: /transcode
     repo: "bluefishforsale_tdarr_plugins"
-    github: "https://github.com/bluefishforsale/{{repo}}.git"
+    # SSH, not anonymous HTTPS: the plugins repo is private, so an unauthenticated
+    # HTTPS clone prompts for a username and fails on ocean ("could not read
+    # Username for https://github.com"). ocean's SSH key authenticates as
+    # bluefishforsale and has access, matching how blog/terrac_com clone.
+    github: "git@github.com:bluefishforsale/{{repo}}.git"
 
   tasks:
   - name: Ensure basedir exists
@@ -63,6 +67,7 @@
       dest: "{{ path_home }}/plugins/"
       depth: 1
       update: yes
+      accept_hostkey: yes
 
   - name: Create tdarr service
     ansible.builtin.template:


### PR DESCRIPTION
## Problem

Every deploy that touches tdarr fails on 'Git clone plugins and flows':
```
fatal: could not read Username for 'https://github.com': No such device or address
```
`bluefishforsale_tdarr_plugins` is a **private** repo, so ocean's anonymous HTTPS clone prompts for a username and fails non-interactively. (This is what turned the ocean apply red after the #262-era full-site run.)

## Fix

Clone over SSH instead. Verified ocean's SSH key authenticates as `bluefishforsale` and `git ls-remote git@github.com:bluefishforsale/bluefishforsale_tdarr_plugins.git` returns HEAD. Same pattern blog_terrac_com / terrac_com already use for private clones. Added `accept_hostkey: yes` so a fresh host isn't blocked on host-key verification.

## Scope

Maps to **only** `tdarr.yaml` (single service) - deploys/recreates tdarr on ocean, does not touch the rest of the fleet.