### PR TITLE
fix(tdarr): use terrac's SSH key for the private plugins clone

### DIFF
--- a/playbooks/individual/ocean/media/tdarr.yaml
+++ b/playbooks/individual/ocean/media/tdarr.yaml
@@ -68,6 +68,12 @@
       depth: 1
       update: yes
       accept_hostkey: yes
+    # The play runs as root, and root has no GitHub key. Point git at terrac's
+    # authorized key (same one terrac_com/blog use) so the private-repo SSH clone
+    # authenticates. IdentitiesOnly avoids offering root's keys and tripping
+    # GitHub's "too many authentication failures".
+    environment:
+      GIT_SSH_COMMAND: "ssh -i /home/terrac/.ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
 
   - name: Create tdarr service
     ansible.builtin.template:


### PR DESCRIPTION
Follow-up to #264. The SSH switch alone still failed because the play runs as **root**, and root has no GitHub key:
```
git@github.com: Permission denied (publickey)
```
Fix: set `GIT_SSH_COMMAND` on the git task to use terrac's authorized key (`/home/terrac/.ssh/id_ed25519`) — the same key/pattern terrac_com and blog_terrac_com use — with `IdentitiesOnly=yes` so root's own keys aren't offered (avoids GitHub's 'too many auth failures').

Verified live: root clones the private repo with this key (2 files). Maps to **tdarr only** (single service).