### PR TITLE
feat(monitoring): ZFS pool health metrics, alerts, and dashboard

### DIFF
--- a/files/grafana-compose/dashboards/ZFS_Pool_Health.json
+++ b/files/grafana-compose/dashboards/ZFS_Pool_Health.json
@@ -1,0 +1,122 @@
+{
+  "title": "ZFS Pool Health",
+  "uid": "zfs-pool-health",
+  "tags": ["zfs", "storage"],
+  "schemaVersion": 40,
+  "version": 1,
+  "editable": true,
+  "time": { "from": "now-24h", "to": "now" },
+  "refresh": "1m",
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Pool Health",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "zpool_health", "legendFormat": "{{pool}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [ { "type": "value", "options": {
+            "0": { "text": "ONLINE", "color": "green", "index": 0 },
+            "1": { "text": "DEGRADED", "color": "yellow", "index": 1 },
+            "2": { "text": "FAULTED", "color": "red", "index": 2 },
+            "3": { "text": "UNKNOWN", "color": "orange", "index": 3 } } } ],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 2 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Faulted Devices",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "sum(zpool_device_faulted) by (pool)", "legendFormat": "{{pool}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Resilver / Scrub Progress",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "zpool_scan_percent", "legendFormat": "{{pool}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": { "min": 0, "max": 100, "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } },
+        "overrides": []
+      },
+      "options": { "showThresholdLabels": false, "showThresholdMarkers": true,
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Resilver Active",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "zpool_resilver_active", "legendFormat": "{{pool}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": { "mappings": [ { "type": "value", "options": {
+          "0": { "text": "idle", "color": "green", "index": 0 },
+          "1": { "text": "RESILVERING", "color": "blue", "index": 1 } } } ] },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Per-device error counters (read/write/cksum)",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "zpool_device_errors > 0", "legendFormat": "{{pool}}/{{device}} {{type}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "showPoints": "auto" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "yellow", "value": null } ] } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Current device state & errors",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "zpool_device_errors", "format": "table", "instant": true, "legendFormat": "", "refId": "A" } ],
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "SMART device health & error-log count",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [
+        { "expr": "smart_device_health_ok", "format": "table", "instant": true, "refId": "A" },
+        { "expr": "smartctl_device_error_log_count", "format": "table", "instant": true, "refId": "B" }
+      ],
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    }
+  ]
+}

--- a/files/node-exporter/zpool-metrics.service.j2
+++ b/files/node-exporter/zpool-metrics.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Publish ZFS pool health to the node_exporter textfile collector
+Documentation=file://{{ node_exporter_files | default('files/node-exporter') }}/zpool-metrics.sh
+After=zfs.target
+
+[Service]
+Type=oneshot
+# Read-only collector: parses `zpool status` and writes zpool.prom. It never
+# mutates the pool. Short-lived; the timer re-runs it.
+ExecStart=/usr/local/bin/zpool-metrics.sh {{ node_exporter_textfiles }}
+Nice=10
+IOSchedulingClass=idle

--- a/files/node-exporter/zpool-metrics.sh
+++ b/files/node-exporter/zpool-metrics.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# zpool-metrics.sh — publish ZFS pool health to the node_exporter textfile
+# collector. READ-ONLY: it only runs `zpool list`/`zpool status` and NEVER
+# mutates a pool (no import/export/mount/replace/clear). Storage changes stay a
+# coordinated, hand-run task (see docs/operations and agents.md). Safe on hosts
+# without ZFS (no-op). Every zpool call is timeout-bounded so a suspended pool
+# cannot hang the collector.
+#
+# Usage: zpool-metrics.sh <textfile_dir>   (writes <dir>/zpool.prom atomically)
+set -uo pipefail
+
+OUTDIR="${1:?usage: zpool-metrics.sh <textfile_dir>}"
+OUT="$OUTDIR/zpool.prom"
+TMP="$OUT.$$.tmp"
+ZT=20 # per-command timeout seconds
+
+zp() { timeout "$ZT" zpool "$@" 2>/dev/null; }
+
+if ! command -v zpool >/dev/null 2>&1; then
+  rm -f "$OUT"          # no ZFS here — clear any stale file
+  exit 0
+fi
+
+health_num() {
+  case "$1" in
+    ONLINE) echo 0 ;;
+    DEGRADED) echo 1 ;;
+    FAULTED|UNAVAIL|SUSPENDED|REMOVED|OFFLINE) echo 2 ;;
+    *) echo 3 ;;
+  esac
+}
+
+# zpool status abbreviates large counts (48, 1.2K, 3M); expand to a plain number.
+num() {
+  case "$1" in
+    *K) awk -v n="${1%K}" 'BEGIN{printf "%.0f", n*1000}' ;;
+    *M) awk -v n="${1%M}" 'BEGIN{printf "%.0f", n*1000000}' ;;
+    *G) awk -v n="${1%G}" 'BEGIN{printf "%.0f", n*1000000000}' ;;
+    ''|*[!0-9]*) echo 0 ;;   # non-numeric (e.g. '-') -> 0
+    *) echo "$1" ;;
+  esac
+}
+
+{
+  echo "# HELP zpool_health Pool health (0=ONLINE 1=DEGRADED 2=FAULTED/other 3=unknown)"
+  echo "# TYPE zpool_health gauge"
+  echo "# HELP zpool_device_errors Per-leaf-device error counter from zpool status"
+  echo "# TYPE zpool_device_errors gauge"
+  echo "# HELP zpool_device_faulted 1 if a leaf device is not ONLINE"
+  echo "# TYPE zpool_device_faulted gauge"
+  echo "# HELP zpool_resilver_active 1 if a resilver/scrub is in progress"
+  echo "# TYPE zpool_resilver_active gauge"
+  echo "# HELP zpool_scan_percent Percent complete of an in-progress scan"
+  echo "# TYPE zpool_scan_percent gauge"
+
+  for pool in $(zp list -H -o name); do
+    echo "zpool_health{pool=\"$pool\"} $(health_num "$(zp list -H -o health "$pool")")"
+
+    status="$(zp status "$pool")"
+    if printf '%s\n' "$status" | grep -qiE "scan:.*(resilver|scrub) in progress"; then
+      echo "zpool_resilver_active{pool=\"$pool\"} 1"
+      pct=$(printf '%s\n' "$status" | grep -oE "[0-9]+\.[0-9]+% done" | grep -oE "[0-9]+\.[0-9]+" | head -1)
+      [ -n "$pct" ] && echo "zpool_scan_percent{pool=\"$pool\"} $pct"
+    else
+      echo "zpool_resilver_active{pool=\"$pool\"} 0"
+    fi
+
+    # Leaf devices only: skip the pool row and vdev-container rows (raidz*, mirror*, ...).
+    printf '%s\n' "$status" | awk -v pool="$pool" '
+      /NAME[ \t]+STATE/ {intable=1; next}
+      /^errors:/ {intable=0}
+      intable && NF>=5 {
+        name=$1; state=$2;
+        if (name==pool) next;
+        if (name ~ /^(raidz|mirror|draid|spare|log|cache|special|dedup|replacing|indirect)/) next;
+        if (state ~ /^(ONLINE|DEGRADED|FAULTED|UNAVAIL|OFFLINE|REMOVED|SUSPENDED)$/)
+          print name"\t"state"\t"$3"\t"$4"\t"$5
+      }' | while IFS=$'\t' read -r dev state r w c; do
+        echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"read\"} $(num "$r")"
+        echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"write\"} $(num "$w")"
+        echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"cksum\"} $(num "$c")"
+        if [ "$state" = "ONLINE" ]; then
+          echo "zpool_device_faulted{pool=\"$pool\",device=\"$dev\"} 0"
+        else
+          echo "zpool_device_faulted{pool=\"$pool\",device=\"$dev\"} 1"
+        fi
+      done
+  done
+} > "$TMP"
+
+mv -f "$TMP" "$OUT"

--- a/files/node-exporter/zpool-metrics.timer.j2
+++ b/files/node-exporter/zpool-metrics.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run zpool-metrics every 60s
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target

--- a/files/ocean-prometheus/alert_rules.yml.j2
+++ b/files/ocean-prometheus/alert_rules.yml.j2
@@ -156,3 +156,37 @@ groups:
     annotations:
       summary: "SMART health check failed for {{ "{{ $labels.device }}" }}"
       description: "Drive {{ "{{ $labels.device }}" }} on {{ "{{ $labels.instance }}" }} has failed SMART health check"
+
+- name: zfs_alerts
+  rules:
+  # Pool not ONLINE. SMART can still report PASSED while ZFS sees a device
+  # faulted, so this is the alert that actually catches a degraded pool.
+  - alert: ZpoolDegraded
+    expr: zpool_health > 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "ZFS pool {{ "{{ $labels.pool }}" }} is not healthy ({{ "{{ $labels.instance }}" }})"
+      description: "zpool_health={{ "{{ $value }}" }} (1=DEGRADED, 2=FAULTED) for {{ "{{ $labels.pool }}" }} on {{ "{{ $labels.instance }}" }}. Check `zpool status`."
+
+  # Per-device read/write/cksum errors accumulating. `for` is long to ride out
+  # transient blips during a resilver.
+  - alert: ZpoolDeviceErrors
+    expr: zpool_device_errors > 0
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      summary: "ZFS device {{ "{{ $labels.device }}" }} has {{ "{{ $labels.type }}" }} errors ({{ "{{ $labels.pool }}" }})"
+      description: "{{ "{{ $value }}" }} {{ "{{ $labels.type }}" }} errors on {{ "{{ $labels.device }}" }} in pool {{ "{{ $labels.pool }}" }} on {{ "{{ $labels.instance }}" }}. A drive is likely failing; see the disk-replacement runbook."
+
+  # Informational: a resilver/scrub is running (visibility, not paging).
+  - alert: ZpoolResilverActive
+    expr: zpool_resilver_active > 0
+    for: 15m
+    labels:
+      severity: info
+    annotations:
+      summary: "ZFS pool {{ "{{ $labels.pool }}" }} is resilvering/scrubbing ({{ "{{ $labels.instance }}" }})"
+      description: "A scan is in progress on {{ "{{ $labels.pool }}" }}. Avoid unnecessary drive operations until it completes."

--- a/playbooks/individual/infrastructure/node_exporter.yaml
+++ b/playbooks/individual/infrastructure/node_exporter.yaml
@@ -73,6 +73,35 @@
       group: root
       mode: '0644'
 
+  # ZFS pool health -> node_exporter textfile collector. Read-only: the script
+  # only parses `zpool status` and NEVER mutates a pool. No-op on non-ZFS hosts.
+  - name: Install zpool-metrics collector script
+    ansible.builtin.copy:
+      src: "{{ node_exporter_files }}/zpool-metrics.sh"
+      dest: /usr/local/bin/zpool-metrics.sh
+      owner: root
+      group: root
+      mode: '0755'
+
+  - name: Create zpool-metrics systemd service
+    ansible.builtin.template:
+      src: "{{ node_exporter_files }}/zpool-metrics.service.j2"
+      dest: /etc/systemd/system/zpool-metrics.service
+      mode: '0644'
+
+  - name: Create zpool-metrics systemd timer
+    ansible.builtin.template:
+      src: "{{ node_exporter_files }}/zpool-metrics.timer.j2"
+      dest: /etc/systemd/system/zpool-metrics.timer
+      mode: '0644'
+
+  - name: Start and enable zpool-metrics timer
+    ansible.builtin.systemd:
+      name: zpool-metrics.timer
+      state: started
+      enabled: true
+      daemon_reload: yes
+
   - name: Create node exporter Docker Compose directory
     ansible.builtin.file:
       path: "{{ node_exporter_home }}"


### PR DESCRIPTION
## Why

The smartctl exporter is deployed and working, but **nothing exposed ZFS pool state** — no metric for pool health, faulted devices, or per-drive read/write/cksum errors, and **no zpool alert**. That's why data01 sat DEGRADED with two faulted drives with no dashboard/alert signal. SMART still reports PASSED on the bad-sector drives, so the existing SMART alert would never have caught it.

## What

- **`zpool-metrics.sh`** — a **read-only** node_exporter textfile collector (parses `zpool status`, never mutates; timeout-bounded; no-op without ZFS). Emits `zpool_health`, `zpool_device_errors{type}`, `zpool_device_faulted`, `zpool_resilver_active`, `zpool_scan_percent`. 60s systemd timer → existing textfile mount, no new container/scrape. **Verified against ocean's live resilvering output.**
- **Alerts**: `ZpoolDegraded` (crit), `ZpoolDeviceErrors` (warn), `ZpoolResilverActive` (info).
- **Dashboard**: ZFS Pool Health (state, faulted count, resilver %, per-device errors, SMART health).

Respects the never-automate-ZFS rule — read-only, guardrail passes. Deploys node_exporter (fleet monitoring agent), prometheus rules, grafana; not the site orchestrator.

Note: on deploy the alerts will immediately fire for data01 — correctly, it IS degraded (b30c1db0 faulted, resilvering).