### PR TITLE
feat(monitoring): drive-wear alerts + dashboard (reallocated/pending sectors)

### DIFF
--- a/files/grafana-compose/dashboards/ZFS_Pool_Health.json
+++ b/files/grafana-compose/dashboards/ZFS_Pool_Health.json
@@ -117,6 +117,34 @@
       ],
       "options": { "showHeader": true },
       "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 8,
+      "type": "table",
+      "title": "Drive wear: reallocated & pending sectors (SMART says PASSED anyway)",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [
+        { "expr": "smartctl_device_attribute{attribute_name=\"Reallocated_Sector_Ct\",attribute_value_type=\"raw\"}", "format": "table", "instant": true, "refId": "A" },
+        { "expr": "smartctl_device_attribute{attribute_name=\"Current_Pending_Sector\",attribute_value_type=\"raw\"}", "format": "table", "instant": true, "refId": "B" }
+      ],
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Reallocated sectors over time (per drive)",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "smartctl_device_attribute{attribute_name=\"Reallocated_Sector_Ct\",attribute_value_type=\"raw\"}", "legendFormat": "{{device}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 5 },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "yellow", "value": null }, { "color": "red", "value": 1000 } ] } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" } }
     }
   ]
 }

--- a/files/ocean-prometheus/alert_rules.yml.j2
+++ b/files/ocean-prometheus/alert_rules.yml.j2
@@ -190,3 +190,33 @@ groups:
     annotations:
       summary: "ZFS pool {{ "{{ $labels.pool }}" }} is resilvering/scrubbing ({{ "{{ $labels.instance }}" }})"
       description: "A scan is in progress on {{ "{{ $labels.pool }}" }}. Avoid unnecessary drive operations until it completes."
+
+- name: disk_wear_alerts
+  rules:
+  # Leading indicators SMART's binary health misses (it reports PASSED even at
+  # 65k reallocated sectors). Alert on the raw counts so a drive pages BEFORE
+  # ZFS faults it. Only clean-count attributes are used (Seagate packs
+  # Raw_Read_Error_Rate / Seek_Error_Rate, so those are deliberately excluded).
+
+  # Pending sectors = unreadable RIGHT NOW, about to reallocate or throw a read
+  # error. Strongest "this drive is actively failing" signal; acute during a
+  # resilver.
+  - alert: DiskPendingSectors
+    expr: smartctl_device_attribute{attribute_name="Current_Pending_Sector",attribute_value_type="raw"} > 0
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ "{{ $labels.device }}" }} has {{ "{{ $value }}" }} pending (unreadable) sectors ({{ "{{ $labels.instance }}" }})"
+      description: "Current_Pending_Sector={{ "{{ $value }}" }} on {{ "{{ $labels.device }}" }} — sectors unreadable now. The drive is developing bad sectors; plan a replacement (see the disk-replacement runbook)."
+
+  # Heavy cumulative reallocation. The drive is coping (remapped to spares) but
+  # this is real wear; at these counts it should be scheduled for replacement.
+  - alert: DiskReallocatedSectorsHigh
+    expr: smartctl_device_attribute{attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw"} > 1000
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ "{{ $labels.device }}" }} has {{ "{{ $value }}" }} reallocated sectors ({{ "{{ $labels.instance }}" }})"
+      description: "Reallocated_Sector_Ct={{ "{{ $value }}" }} on {{ "{{ $labels.device }}" }}. SMART may still report PASSED; this is heavy wear — schedule replacement."


### PR DESCRIPTION
Follow-up to #267. SMART reports **PASSED** even on a drive with 65,880 reallocated sectors, so its binary health check can't catch a failing drive before ZFS faults it. Alert on the raw leading indicators:

- **DiskPendingSectors** (warn): `Current_Pending_Sector > 0` — unreadable-now sectors, the acute signal. Matches sdi (8) live.
- **DiskReallocatedSectorsHigh** (warn): `Reallocated_Sector_Ct > 1000` — heavy wear. Matches sde (65,880) and sdd (6,824) live.

Seagate-packed attributes (Raw_Read/Seek error rates) are deliberately excluded. Dashboard gets a wear table + reallocated-over-time graph. Deploys prometheus + grafana only.