### PR TITLE
fix(certbot): mask Debian certbot.timer to stop it racing certbot-renew

### DIFF
--- a/playbooks/individual/ocean/network/certbot.yaml
+++ b/playbooks/individual/ocean/network/certbot.yaml
@@ -92,6 +92,28 @@
       daemon_reload: true
     tags: [service]
 
+  # The certbot package ships its own certbot.timer/.service. Left enabled, it
+  # races our certbot-renew unit (both fire, collide on certbot's lock -> one
+  # exits 1 -> SystemdUnitFailed alert), and worse, if the Debian timer wins the
+  # race it renews WITHOUT our Plex deploy-hook. Mask it so certbot-renew is the
+  # only renewal path.
+  - name: Mask the Debian-packaged certbot timer and service
+    ansible.builtin.systemd:
+      name: "{{ item }}"
+      masked: true
+      enabled: false
+      state: stopped
+    loop:
+      - certbot.timer
+      - certbot.service
+    tags: [service]
+
+  - name: Clear any stale failed state on certbot-renew (from a past collision)
+    ansible.builtin.command: systemctl reset-failed {{ service }}.service
+    changed_when: false
+    failed_when: false
+    tags: [service]
+
   - name: Check if certificate already exists and is valid
     ansible.builtin.command:
       cmd: "certbot certificates --cert-name {{ domain }}"


### PR DESCRIPTION
## Cause

The `SystemdUnitFailed: certbot-renew.service` alert came from **two enabled certbot timers** on ocean: our custom `certbot-renew.timer` (with the Plex deploy-hook) and the Debian-packaged `certbot.timer`. They fired at the same second, collided on certbot's lock file, and one exited 1. The cert itself was fine (valid 76 days). Running the command by hand (no collision) succeeds.

Extra hazard: if the Debian timer wins the race and renews, it does so **without the Plex deploy-hook**, so Plex wouldn't get the new cert.

## Fix

Mask `certbot.timer` + `certbot.service` (Debian units) so `certbot-renew` is the only renewal path, and `reset-failed` to clear the stale failed state from the last collision. Maps to certbot only (single service).