### PR TITLE
fix(prometheus): scrape alertmanager (fixes N/A Grafana dashboard)

### DIFF
--- a/files/ocean-prometheus/prometheus.yml.j2
+++ b/files/ocean-prometheus/prometheus.yml.j2
@@ -46,6 +46,11 @@ scrape_configs:
     static_configs:
     - targets: ['ocean.home:9090']
 
+  - job_name: 'alertmanager'
+    relabel_configs: *dropPortNumber
+    static_configs:
+    - targets: ['ocean.home:9093']
+
   - job_name: 'node_exporter'
     scrape_interval: 30s
     scrape_timeout: 30s


### PR DESCRIPTION
## Problem
Grafana **Alertmanager** dashboard showed `N/A` on every panel.

## Root cause
`files/ocean-prometheus/prometheus.yml.j2` configured alertmanager only as an alert *receiver* (`alerting.alertmanagers → ocean.home:9093`) but had **no scrape job** for it. So `alertmanager_build_info` and all `alertmanager_*` series were never collected. The dashboard's `instance` template var (`query_result(alertmanager_build_info)`) returned nothing, N/A-ing every panel.

## Fix
Added an `alertmanager` scrape job targeting `ocean.home:9093`, reusing the `*dropPortNumber` relabel so `instance=ocean.home` (matches the dashboard var regex).

## Deploy note
`files/**` change — needs a manual prometheus deploy/reload after merge; not picked up by a bare push.