### PR TITLE
fix(zfs-metrics): faulted count = only FAULTED, add per-state panel

### DIFF
--- a/files/grafana-compose/dashboards/ZFS_Pool_Health.json
+++ b/files/grafana-compose/dashboards/ZFS_Pool_Health.json
@@ -145,6 +145,26 @@
       },
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
         "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+    {
+      "id": 10,
+      "type": "bargauge",
+      "title": "Drives per state",
+      "description": "Count of leaf devices in each ZFS state. FAULTED = disk out; DEGRADED/REMOVED/OFFLINE = impaired but not faulted (e.g. mid-replace or flaky-but-serving).",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "bf02tpxiz6m0wf" },
+      "targets": [ { "expr": "count by (state) (zpool_device_state)", "legendFormat": "{{state}}", "refId": "A" } ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "text" } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "FAULTED" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } } ] },
+          { "matcher": { "id": "byName", "options": "DEGRADED" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } } ] },
+          { "matcher": { "id": "byName", "options": "REMOVED" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } } ] },
+          { "matcher": { "id": "byName", "options": "ONLINE" }, "properties": [ { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } } ] }
+        ]
+      },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "showUnfilled": true,
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } }
     }
   ]
 }

--- a/files/node-exporter/zpool-metrics.sh
+++ b/files/node-exporter/zpool-metrics.sh
@@ -46,8 +46,10 @@ num() {
   echo "# TYPE zpool_health gauge"
   echo "# HELP zpool_device_errors Per-leaf-device error counter from zpool status"
   echo "# TYPE zpool_device_errors gauge"
-  echo "# HELP zpool_device_faulted 1 if a leaf device is not ONLINE"
+  echo "# HELP zpool_device_faulted 1 only if a leaf device is FAULTED (DEGRADED/REMOVED/OFFLINE are not faulted)"
   echo "# TYPE zpool_device_faulted gauge"
+  echo "# HELP zpool_device_state Current leaf-device state, 1 on the state label that is currently active"
+  echo "# TYPE zpool_device_state gauge"
   echo "# HELP zpool_resilver_active 1 if a resilver/scrub is in progress"
   echo "# TYPE zpool_resilver_active gauge"
   echo "# HELP zpool_scan_percent Percent complete of an in-progress scan"
@@ -79,11 +81,15 @@ num() {
         echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"read\"} $(num "$r")"
         echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"write\"} $(num "$w")"
         echo "zpool_device_errors{pool=\"$pool\",device=\"$dev\",type=\"cksum\"} $(num "$c")"
-        if [ "$state" = "ONLINE" ]; then
-          echo "zpool_device_faulted{pool=\"$pool\",device=\"$dev\"} 0"
-        else
+        # FAULTED means the disk is out; DEGRADED/REMOVED/OFFLINE are impaired but
+        # not faulted (e.g. a mid-replace REMOVED old drive, or a flaky-but-serving
+        # DEGRADED disk). Conflating them over-counts "faulted" (see #283 resilver).
+        if [ "$state" = "FAULTED" ]; then
           echo "zpool_device_faulted{pool=\"$pool\",device=\"$dev\"} 1"
+        else
+          echo "zpool_device_faulted{pool=\"$pool\",device=\"$dev\"} 0"
         fi
+        echo "zpool_device_state{pool=\"$pool\",device=\"$dev\",state=\"$state\"} 1"
       done
   done
 } > "$TMP"


### PR DESCRIPTION
## Problem
The **ZFS Pool Health** dashboard's *Faulted Devices* panel read **3** during the data01 resilver (#283), but only **one** disk is genuinely FAULTED.

## Root cause
`zpool-metrics.sh` set `zpool_device_faulted=1` for **any non-ONLINE** leaf device:
```
if [ "$state" = "ONLINE" ]; then ... 0; else ... 1; fi
```
So it counted sdh (FAULTED) + sde (DEGRADED, flaky-but-serving) + the old drive mid-`replace` (REMOVED) = 3.

## Fix
- `zpool_device_faulted` now `1` **only** when `state == FAULTED`. DEGRADED / REMOVED / OFFLINE are impaired but not faulted.
- New enum gauge `zpool_device_state{...,state="<STATE>"} 1` for a real per-state count.
- Dashboard: added a **Drives per state** bargauge (`count by (state) (zpool_device_state)`, FAULTED=red / DEGRADED=orange / REMOVED=yellow / ONLINE=green). The existing *Faulted Devices* panel now reads the true count with no query change.

Verified the leaf-device parser against the live `data01` status: 1 faulted (sdh), sde=DEGRADED, old drive=REMOVED, `replacing-5` container row skipped.

## Deploy note
`files/**` change. Collector + dashboard reach ocean via manual dispatch, not a bare push. No alert touches `zpool_device_faulted` (ZpoolDegraded is `zpool_health > 0`), so no alert-semantics change.