### PR TITLE
docs(roadmap): daily reconcile against live fleet

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,10 @@ Status and future plans for the homelab infrastructure.
 - **Cloudflare Exporter**: Cloudflare metrics exporter for Prometheus
 - **ntfy**: Push notification service
 - **cAdvisor**: Per-container resource metrics exporter
+- **Blackbox Exporter**: HTTP, DNS, ICMP, and TCP endpoint probing
+- **Process Exporter**: Per-process resource metrics
+- **SMART Exporter**: Disk SMART health and drive-wear metrics
+- **MTR Exporter**: Network path latency metrics
 
 ### Cloud/CMS Services
 


### PR DESCRIPTION
Automated daily reconcile by agentbox. Todo items now deployed+healthy were moved to Completed and live-but-unlisted work was added, strictly from Prometheus/Alertmanager + playbook evidence. No future or speculative items were added. Review the diff and merge (homelab is infra: a human merges, ADR 0001).