### PR TITLE
fix(grafana): dashboards hot-reload on deploy, no container recreate

### DIFF
--- a/.github/workflows/lib/detect-impacted-playbooks.sh
+++ b/.github/workflows/lib/detect-impacted-playbooks.sh
@@ -77,9 +77,13 @@ emit() {
   #     file handles or lose data. Name any storage play *zfs*.yaml to inherit
   #     this guard. (The play itself is read-only; a CI guardrail also forbids
   #     mutating ZFS verbs in any playbook.)
+  #   - operations/backup/**: backups pull live state INTO the repo; running one
+  #     as a push-deploy is backwards (e.g. the grafana backup exports live
+  #     dashboards over the committed change). Backups are scheduled/hand-run.
   case "$pb" in
     playbooks/individual/ocean/ai/terminalbench*.yaml) return 0 ;;
     playbooks/*zfs*.yaml | playbooks/*zfs*.yml) return 0 ;;
+    playbooks/operations/backup/*) return 0 ;;
   esac
   if ! grep -qxF "$pb" "$SEEN_FILE" 2>/dev/null; then
     printf '%s\n' "$pb" >> "$SEEN_FILE"

--- a/.github/workflows/lib/detect-impacted-playbooks.test.sh
+++ b/.github/workflows/lib/detect-impacted-playbooks.test.sh
@@ -191,6 +191,19 @@ assert_eq "mixed playbook+workflow commit keeps only the playbook" \
 out=$(printf 'playbooks/individual/ocean/data01_zfs.yaml\n' | bash "$SCRIPT")
 assert_eq "zfs playbook is dispatch-only (never auto-applies)" "[]" "$out"
 
+# 30. A dashboard JSON change deploys ONLY via grafana_compose. The backup
+#     playbook grafana_dashboards.yaml also references files/grafana-compose but
+#     must NOT run as a deploy (it exports live dashboards over the committed
+#     change) — it is filtered at emit() as an operations/backup playbook.
+out=$(printf 'files/grafana-compose/dashboards/ZFS_Pool_Health.json\n' | bash "$SCRIPT")
+assert_eq "dashboard change maps to grafana_compose only (backup excluded)" \
+  '["playbooks/individual/ocean/monitoring/grafana_compose.yaml"]' "$out"
+
+# 31. A direct edit to a backup playbook maps to nothing (backups are
+#     scheduled/hand-run, never a push-deploy).
+out=$(printf 'playbooks/operations/backup/grafana_dashboards.yaml\n' | bash "$SCRIPT")
+assert_eq "backup playbook never auto-applies" "[]" "$out"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/playbooks/individual/ocean/monitoring/grafana_compose.yaml
+++ b/playbooks/individual/ocean/monitoring/grafana_compose.yaml
@@ -187,10 +187,16 @@
       mode: '0600'
     register: grafana_env
 
+  # NOTE: grafana_dashboards.changed is deliberately absent from the recreate
+  # gate below. Dashboard JSON is file-provisioned (updateIntervalSeconds: 30,
+  # allowUiUpdates) and hot-reloaded from the mounted dir with no restart;
+  # recreating Grafana+MySQL for a dashboard edit is a needless monitoring blip.
+  # The provider CONFIG (grafana_dashboard_provisioning) still recreates because
+  # Grafana only reads provisioning at startup.
   - name: Show what configuration files changed
     ansible.builtin.debug:
       msg: "Configuration files have been updated - containers will be recreated"
-    when: mysql_init_script.changed or mysql_config.changed or grafana_config.changed or docker_compose_config.changed or grafana_env.changed or grafana_users_config.changed or grafana_loki_datasource.changed or grafana_dashboard_provisioning.changed or grafana_dashboards.changed
+    when: mysql_init_script.changed or mysql_config.changed or grafana_config.changed or docker_compose_config.changed or grafana_env.changed or grafana_users_config.changed or grafana_loki_datasource.changed or grafana_dashboard_provisioning.changed
 
   - name: Create grafana systemd service
     ansible.builtin.template:
@@ -214,7 +220,7 @@
       docker compose down --timeout 30
       docker compose up -d --force-recreate
       echo "Container recreation completed"
-    when: mysql_init_script.changed or mysql_config.changed or grafana_config.changed or docker_compose_config.changed or grafana_env.changed or grafana_users_config.changed or grafana_loki_datasource.changed or grafana_dashboard_provisioning.changed or grafana_dashboards.changed
+    when: mysql_init_script.changed or mysql_config.changed or grafana_config.changed or docker_compose_config.changed or grafana_env.changed or grafana_users_config.changed or grafana_loki_datasource.changed or grafana_dashboard_provisioning.changed
 
   handlers:
   - name: Reload systemd daemon


### PR DESCRIPTION
## Problem
The dashboard change in #286 exposed a gap: a dashboard-only edit *does* map to a deploy, but the deploy does the **wrong action**.

## Findings
1. **Needless restart.** `grafana_compose.yaml` recreated Grafana+MySQL (`docker compose down && up --force-recreate`) on any dashboard change. Dashboards are file-provisioned (`updateIntervalSeconds: 30`, `allowUiUpdates`) and hot-reload from the mounted dir with no restart. Recreating for a dashboard edit is a monitoring blip for nothing.
2. **Backup ran as a deploy.** The impact-detector also matched `playbooks/operations/backup/grafana_dashboards.yaml` (it references `files/grafana-compose`), which exports **live** dashboards back into the checkout, i.e. over the committed change.

## Fix
- Dropped `grafana_dashboards.changed` from both recreate gates in `grafana_compose.yaml`. The provider **config** (`grafana_dashboard_provisioning`) still recreates, since Grafana only reads provisioning at startup.
- Filtered `playbooks/operations/backup/*` at the detector's `emit()` never-auto-apply chokepoint, next to the existing `terminalbench` and `*zfs*` guards.

## Result
A dashboard edit copies the JSON to `{{ home }}/dashboards/` and Grafana reloads it within 30s, no restart, no backup run.

## Tests
`detect-impacted-playbooks.test.sh`: 30 pass, including two new cases, dashboard change maps to `grafana_compose` only, and a backup-playbook edit maps to nothing.